### PR TITLE
Add query_tuner_am_step command

### DIFF
--- a/aiopioneer/commands.py
+++ b/aiopioneer/commands.py
@@ -114,6 +114,7 @@ PIONEER_COMMANDS = {
     "set_amp_panel_lock": {"1": ["PKL", "PKL"]},
     "set_amp_remote_lock": {"1": ["RML", "RML"]},
     "query_tuner_preset": {"1": ["?PR", "PR"]},
+    "query_tuner_am_step": {"1": ["?SUQ", "SUQ"]},
     "set_tuner_preset": {"1": ["PR", "PR"]},
     "increase_tuner_preset": {"1": ["TPI", "PR"]},
     "decrease_tuner_preset": {"1": ["TPD", "PR"]},

--- a/aiopioneer/parsers/parse.py
+++ b/aiopioneer/parsers/parse.py
@@ -93,6 +93,7 @@ RESPONSE_DATA = [
     ["FRF", TunerParsers.frequency_fm, None],
     ["FRA", TunerParsers.frequency_am, None],
     ["PR", TunerParsers.preset, None],
+    ["SUQ", TunerParsers.am_frequency_step, None],
 
     ["MC", DspParsers.mcacc_setting, None],
     ["IS", DspParsers.phasecontrol, None],

--- a/aiopioneer/parsers/tuner.py
+++ b/aiopioneer/parsers/tuner.py
@@ -80,3 +80,19 @@ class TunerParsers():
                             queue_commands=None))
 
         return parsed
+
+    @staticmethod
+    def am_frequency_step(raw: str, _param: dict, zone = None, command = "SUQ") -> list:
+        """Response parser for frequency step.
+        NOTE: This is supported on very few AVRs"""
+
+        parsed = []
+        parsed.append(Response(raw=raw,
+                            response_command=command,
+                            base_property="_params",
+                            property_name=PARAM_TUNER_AM_FREQ_STEP,
+                            zone=zone,
+                            value=9 if raw == "0" else 10,
+                            queue_commands=None))
+
+        return parsed

--- a/aiopioneer/pioneer_avr.py
+++ b/aiopioneer/pioneer_avr.py
@@ -1268,6 +1268,8 @@ class PioneerAVR:
         up and then down.
         """
         _LOGGER.debug(">> PioneerAVR._calculate_am_frequency_step() ")
+        # Try sending the query_tuner_am_step command first.
+        await self.send_command(command="query_tuner_am_step", ignore_error=True)
         # Check if freq step is None, band is set to AM and current source is
         # set to tuner for at least one zone. This function otherwise does not work.
         if (


### PR DESCRIPTION
Small PR to add a parser for the SUQ command. Its not supported on many AVRs, but the ones it is supported on this should take away an extra step in needing to configure that and also speed up the calculation of the am frequency step as we're not dependant on increasing and decreasing the frequency.