### PR TITLE
Add set_source_name function

### DIFF
--- a/aiopioneer/commands.py
+++ b/aiopioneer/commands.py
@@ -288,4 +288,6 @@ PIONEER_COMMANDS = {
     "operation_amp_channel_select": {"1": "CLC"},
     "operation_amp_home_menu": {"1": "HM"},
     "operation_amp_key_off": {"1": "KOF"},
+    "set_input_name": {"1": ["1RGB", "RGB"]},
+    "set_default_input_name": {"1": ["0RGB", "RGB"]}
 }

--- a/aiopioneer/pioneer_avr.py
+++ b/aiopioneer/pioneer_avr.py
@@ -600,7 +600,7 @@ class PioneerAVR:
                         return False
 
     async def send_command(
-        self, command, zone="1", prefix="", ignore_error=None, rate_limit=True
+        self, command, zone="1", prefix="", ignore_error=None, rate_limit=True, suffix=""
     ):
         """Send a command or request to the device."""
         # pylint: disable=unidiomatic-typecheck disable=logging-not-lazy
@@ -608,12 +608,13 @@ class PioneerAVR:
         if debug_command:
             _LOGGER.debug(
                 '>> PioneerAVR.send_command("%s", zone="%s", prefix="%s", '
-                + "ignore_error=%s, rate_limit=%s)",
+                + "ignore_error=%s, rate_limit=%s, suffix=%s)",
                 command,
                 zone,
                 prefix,
                 ignore_error,
                 rate_limit,
+                suffix,
             )
         raw_command = PIONEER_COMMANDS.get(command, {}).get(zone)
         try:
@@ -623,7 +624,7 @@ class PioneerAVR:
                     expected_response = raw_command[1]
                     raw_command = raw_command[0]
                     response = await self.send_raw_request(
-                        prefix + raw_command,
+                        prefix + raw_command + suffix,
                         expected_response,
                         ignore_error,
                         rate_limit,
@@ -635,7 +636,7 @@ class PioneerAVR:
                     _LOGGER.error("invalid request %s for zone %s", raw_command, zone)
                     return None
             elif type(raw_command) is str:
-                return await self.send_raw_command(prefix + raw_command, rate_limit)
+                return await self.send_raw_command(prefix + raw_command + suffix, rate_limit)
             else:
                 _LOGGER.warning("invalid command %s for zone %s", command, zone)
                 return None

--- a/aiopioneer/pioneer_avr.py
+++ b/aiopioneer/pioneer_avr.py
@@ -1797,14 +1797,22 @@ class PioneerAVR:
                 "media_control activities."
             )
 
-    async def set_source_name(self, source_id: str, name: str = "", default: bool = False):
-        """Renames a given source, set the default parameter to true to reset to default."""
+    async def set_input_name(self, input_id: str, name: str = "", default: bool = False):
+        """Renames a given input, set the default parameter to true to reset to default."""
         if default:
-            await self.send_raw_command(f"0RGB{source_id}")
+            await self.send_command(
+                command="set_default_input_name",
+                zone="1",
+                suffix=input_id)
         else:
             if len(name) > 14:
-                raise ValueError(f"New source name ({name}) length too long. "
+                raise ValueError(f"New input name ({name}) length too long. "
                                  "Up to 14 characters are allowed")
-            if self._source_id_to_name.get(source_id) is not name:
-                await self.send_raw_command(f"{name}1RGB{source_id}")
+            if self._source_id_to_name.get(input_id) is not name:
+                await self.send_command(
+                    command="set_input_name",
+                    zone="1",
+                    prefix=name,
+                    suffix=input_id
+                )
         return True

--- a/aiopioneer/pioneer_avr.py
+++ b/aiopioneer/pioneer_avr.py
@@ -1795,3 +1795,15 @@ class PioneerAVR:
                 f"Current source ({self.source.get(zone)}) does not support "
                 "media_control activities."
             )
+
+    async def set_source_name(self, source_id: str, name: str = "", default: bool = False):
+        """Renames a given source, set the default parameter to true to reset to default."""
+        if default:
+            await self.send_raw_command(f"0RGB{source_id}")
+        else:
+            if len(name) > 14:
+                raise ValueError(f"New source name ({name}) length too long. "
+                                 "Up to 14 characters are allowed")
+            if self._source_id_to_name.get(source_id) is not name:
+                await self.send_raw_command(f"{name}1RGB{source_id}")
+        return True


### PR DESCRIPTION
Adds a basic function to set and reset source names. (replicating iControlAV5 functionality)

Source names cannot be longer than 14 characters so a ValueError is raised in the event that a new name is provided longer than 14 chars.

Also, setting the `default` paramter to True will reset the source name to its default value.