### PR TITLE
Fix 'NoneType' object has no attribute 'get'

### DIFF
--- a/aiopioneer/pioneer_avr.py
+++ b/aiopioneer/pioneer_avr.py
@@ -1368,7 +1368,7 @@ class PioneerAVR:
         """Set the listening mode using the predefined list of options in params."""
         self._check_zone(zone)
 
-        if self.audio.get(zone).get("input_multichannel"):
+        if self.audio.get("input_multichannel"):
             listening_mode_key = [
                 k
                 for k, v in LISTENING_MODES.items()


### PR DESCRIPTION
Fix for

Traceback (most recent call last):
  File "/usr/src/homeassistant/homeassistant/components/websocket_api/commands.py", line 199, in handle_call_service
    await hass.services.async_call(
  File "/usr/src/homeassistant/homeassistant/core.py", line 1820, in async_call
    task.result()
  File "/usr/src/homeassistant/homeassistant/core.py", line 1857, in _execute_service
    await cast(Callable[[ServiceCall], Awaitable[None]], handler.job.target)(
  File "/usr/src/homeassistant/homeassistant/helpers/entity_component.py", line 216, in handle_service
    await service.entity_service_call(
  File "/usr/src/homeassistant/homeassistant/helpers/service.py", line 798, in entity_service_call
    future.result()  # pop exception if have
  File "/usr/src/homeassistant/homeassistant/helpers/entity.py", line 977, in async_request_call
    await coro
  File "/usr/src/homeassistant/homeassistant/helpers/service.py", line 838, in _handle_entity_call
    await result
  File "/config/custom_components/pioneer_async/media_player.py", line 636, in async_select_sound_mode
    return await self._pioneer.set_listening_mode(sound_mode, self._zone)
  File "/usr/local/lib/python3.10/site-packages/aiopioneer/pioneer_avr.py", line 1370, in set_listening_mode
    if self.audio.get(zone).get("input_multichannel"):
AttributeError: 'NoneType' object has no attribute 'get'