### PR TITLE
AVR generation specific parsing

### DIFF
--- a/aiopioneer/const.py
+++ b/aiopioneer/const.py
@@ -19,6 +19,20 @@ class Zones(Enum):
         return self.value
 
 
+class AvrGenerations(Enum):
+    """AVR Generations"""
+    FY10 = "FY10"
+    FY11 = "FY11"
+    FY12 = "FY12"
+    FY13 = "FY13"
+    FY14 = "FY14"
+    FY15 = "FY15"
+    FY16 = "FY16"
+
+    def __str__(self) -> str:
+        return self.value
+
+
 # Listening modes is a dict with a nested array for the following structure:
 # key (display name, 2ch sources, multichannel sources)
 LISTENING_MODES = {

--- a/aiopioneer/param.py
+++ b/aiopioneer/param.py
@@ -2,7 +2,7 @@
 # pylint: disable=too-many-lines
 
 from collections import OrderedDict
-from .const import Zones
+from .const import Zones, AvrGenerations
 
 PARAM_IGNORED_ZONES = "ignored_zones"
 PARAM_COMMAND_DELAY = "command_delay"
@@ -21,6 +21,7 @@ PARAM_ZONE_1_SOURCES = "zone_1_sources"  ## All possible valid input sources for
 PARAM_ZONE_2_SOURCES = "zone_2_sources"  ## All possible valid input sources for Zone 2
 PARAM_ZONE_3_SOURCES = "zone_3_sources"  ## All possible valid input sources for Zone 3
 PARAM_HDZONE_SOURCES = "hdzone_sources"  ## All possible valid input sources for HDZone
+PARAM_AVR_GENERATION = "avr_generation"  ## The specific AVR generation, defaults to None
 PARAM_ZONE_SOURCES = {
     Zones.Z1: PARAM_ZONE_1_SOURCES,
     Zones.Z2: PARAM_ZONE_2_SOURCES,
@@ -181,6 +182,7 @@ PARAM_DEFAULTS = {
     PARAM_VIDEO_RESOLUTION_MODES: ["0", "1", "3", "4", "5", "6", "7", "8", "9"],
     PARAM_MHL_SOURCE: None,
     PARAM_TUNER_AM_FREQ_STEP: None,
+    PARAM_AVR_GENERATION: None,
 }
 
 PARAMS_ALL = PARAM_DEFAULTS.keys()
@@ -1373,5 +1375,8 @@ PARAM_MODEL_DEFAULTS = OrderedDict(
         ),
         (r"^VSX-45", {PARAM_HDZONE_VOLUME_REQUIREMENTS: []}),
         (r"^VSX-830", {PARAM_HDZONE_VOLUME_REQUIREMENTS: []}),
+        (r"^VSX-828", {PARAM_AVR_GENERATION: AvrGenerations.FY10}),
+        (r"^VSX-1120", {PARAM_AVR_GENERATION: AvrGenerations.FY10}),
+        (r"^VSX-922", {PARAM_AVR_GENERATION: AvrGenerations.FY13})
     ]
 )


### PR DESCRIPTION
Upon looking over docs for different AVR generations from the past 13 years at least, I've spotted that some parameters have different lengths with different data bits.

This PR is to introduce logic to aiopioneer to support the following:

- [ ] AVR generations (been thinking about this on and off for a while to be honest)
- [ ] Better parsing of `AST` and `VST` taking into account different generations

In a future PR I'd like to create some class overrides for different commands based on different AvrGenerations values