### PR TITLE
Simplify update_zone logic

### DIFF
--- a/aiopioneer/pioneer_avr.py
+++ b/aiopioneer/pioneer_avr.py
@@ -1188,10 +1188,12 @@ class PioneerAVR:
         # All zone updates
         if (
             await self.send_command("query_power", zone, ignore_error=True) is None
-            or await self.send_command("query_volume", zone, ignore_error=True) is None
-            or await self.send_command("query_mute", zone, ignore_error=True) is None
-            or await self.send_command("query_source_id", zone, ignore_error=True)
-            is None
+            or bool(self.power.get(zone)) and (
+                await self.send_command("query_volume", zone, ignore_error=True) is None
+                or await self.send_command("query_mute", zone, ignore_error=True) is None
+                or await self.send_command("query_source_id", zone, ignore_error=True)
+                is None
+            )
         ):
             # Timeout occurred, indicates AVR disconnected
             raise TimeoutError("Timeout waiting for data")


### PR DESCRIPTION
Avoid duplicate checks and loops and follow a simple structure:
    
1. Update power state and skip all further updates if power is off, since those might not work anyway.
2. Update generic properties that should always be supported.
3. Update everything else that is supported by the respective zone, unless disabled via PARAM_DISABLE_AUTO_QUERY or PARAM_ENABLED_FUNCTIONS.