### PR TITLE
Separate params and AVR properties into separate instantiated classes

### DIFF
--- a/aiopioneer/cli.py
+++ b/aiopioneer/cli.py
@@ -69,7 +69,7 @@ async def cli_main(args: argparse.Namespace):
     pioneer.params.set_user_param(PARAM_DEBUG_LISTENER, True)
     if args.query_zones:
         await pioneer.query_zones()
-        _LOGGER.info("AVR zones discovered: %s", pioneer.zones)
+        _LOGGER.info("AVR zones discovered: %s", pioneer.properties.zones)
 
     reader, _writer = await connect_stdin_stdout()
     zone = Zones.Z1
@@ -87,7 +87,7 @@ async def cli_main(args: argparse.Namespace):
         arg = None if num_tokens == 1 else tokens[1]
         if cmd == "zone":
             zone_new = Zones(arg)
-            if zone_new and zone_new in pioneer.zones:
+            if zone_new and zone_new in pioneer.properties.zones:
                 zone = zone_new
                 print(f"Setting current zone to {zone}")
             else:
@@ -104,24 +104,24 @@ async def cli_main(args: argparse.Namespace):
         elif cmd == "query_device_info":
             await pioneer.query_device_info()
             print(
-                f"Device info: model={pioneer.model}, "
-                f"mac_addr={pioneer.mac_addr}, "
-                f"software_version={pioneer.software_version}"
+                f"Device info: model={pioneer.properties.model}, "
+                f"mac_addr={pioneer.properties.mac_addr}, "
+                f"software_version={pioneer.properties.software_version}"
             )
         elif cmd == "query_zones":
             await pioneer.query_zones()
-            print(f"Zones discovered: {pioneer.zones}")
+            print(f"Zones discovered: {pioneer.properties.zones}")
         elif cmd == "build_source_dict":
             await pioneer.build_source_dict()
         elif cmd == "set_source_dict":
             try:
                 source_dict = json.loads(arg)
                 print(f"Setting source dict to: {json.dumps(source_dict)}")
-                pioneer.set_source_dict(source_dict)
+                pioneer.properties.set_source_dict(source_dict)
             except json.JSONDecodeError:
                 print(f'ERROR: Invalid JSON source dict: "{arg}""')
         elif cmd == "get_source_list":
-            print(f"Source list: {json.dumps(pioneer.get_source_list())}")
+            print(f"Source list: {json.dumps(pioneer.properties.get_source_list())}")
         elif cmd == "get_zone_listening_modes":
             print(
                 f"Available listening modes: {json.dumps(pioneer.get_listening_modes())}"
@@ -140,26 +140,26 @@ async def cli_main(args: argparse.Namespace):
 
         elif cmd == "get_tone":
             audio_attrs = {
-                "listening_mode": pioneer.listening_mode,
-                "listening_mode_raw": pioneer.listening_mode_raw,
-                "media_control_mode": pioneer.media_control_mode,
-                "tone": pioneer.tone,
+                "listening_mode": pioneer.properties.listening_mode,
+                "listening_mode_raw": pioneer.properties.listening_mode_raw,
+                "media_control_mode": pioneer.properties.media_control_mode,
+                "tone": pioneer.properties.tone,
             }
             print(json.dumps(audio_attrs))
         elif cmd == "get_amp":
-            print(json.dumps(pioneer.amp))
+            print(json.dumps(pioneer.properties.amp))
         elif cmd == "get_tuner":
-            print(json.dumps(pioneer.tuner))
+            print(json.dumps(pioneer.properties.tuner))
         elif cmd == "get_channel_levels":
-            print(json.dumps(pioneer.channel_levels))
+            print(json.dumps(pioneer.properties.channel_levels))
         elif cmd == "get_dsp":
-            print(json.dumps(pioneer.dsp))
+            print(json.dumps(pioneer.properties.dsp))
         elif cmd == "get_video":
-            print(json.dumps(pioneer.video))
+            print(json.dumps(pioneer.properties.video))
         elif cmd == "get_audio":
-            print(json.dumps(pioneer.audio))
+            print(json.dumps(pioneer.properties.audio))
         elif cmd == "get_system":
-            print(json.dumps(pioneer.system))
+            print(json.dumps(pioneer.properties.system))
 
         elif cmd == "debug_listener":
             arg_bool = get_bool_arg(arg)

--- a/aiopioneer/cli.py
+++ b/aiopioneer/cli.py
@@ -65,8 +65,8 @@ async def cli_main(args: argparse.Namespace):
 
     await pioneer.query_device_model()
     set_log_level("debug")
-    print(f"Using default params: {pioneer.user_params}")
-    pioneer.set_user_param(PARAM_DEBUG_LISTENER, True)
+    print(f"Using default params: {pioneer.params.user_params}")
+    pioneer.params.set_user_param(PARAM_DEBUG_LISTENER, True)
     if args.query_zones:
         await pioneer.query_zones()
         _LOGGER.info("AVR zones discovered: %s", pioneer.zones)
@@ -127,14 +127,14 @@ async def cli_main(args: argparse.Namespace):
                 f"Available listening modes: {json.dumps(pioneer.get_listening_modes())}"
             )
         elif cmd == "get_params":
-            print(f"Params: {json.dumps(pioneer.params_all)}")
+            print(f"Params: {json.dumps(pioneer.params.params_all)}")
         elif cmd == "get_user_params":
-            print(f"User Params: {json.dumps(pioneer.user_params)}")
+            print(f"User Params: {json.dumps(pioneer.params.user_params)}")
         elif cmd == "set_user_params":
             try:
                 params = json.loads(arg)
                 print(f"Set user params: {json.dumps(params)}")
-                pioneer.set_user_params(params)
+                pioneer.params.set_user_params(params)
             except json.JSONDecodeError:
                 print(f'ERROR: Invalid JSON params: "{arg}""')
 
@@ -164,19 +164,19 @@ async def cli_main(args: argparse.Namespace):
         elif cmd == "debug_listener":
             arg_bool = get_bool_arg(arg)
             print(f"Setting debug_listener to: {arg_bool}")
-            pioneer.set_user_param(PARAM_DEBUG_LISTENER, arg_bool)
+            pioneer.params.set_user_param(PARAM_DEBUG_LISTENER, arg_bool)
         elif cmd == "debug_responder":
             arg_bool = get_bool_arg(arg)
             print(f"Setting debug_responder to: {arg_bool}")
-            pioneer.set_user_param(PARAM_DEBUG_RESPONDER, arg_bool)
+            pioneer.params.set_user_param(PARAM_DEBUG_RESPONDER, arg_bool)
         elif cmd == "debug_updater":
             arg_bool = get_bool_arg(arg)
             print(f"Setting debug_updater to: {arg_bool}")
-            pioneer.set_user_param(PARAM_DEBUG_UPDATER, arg_bool)
+            pioneer.params.set_user_param(PARAM_DEBUG_UPDATER, arg_bool)
         elif cmd == "debug_command":
             arg_bool = get_bool_arg(arg)
             print(f"Setting debug_command to: {arg_bool}")
-            pioneer.set_user_param(PARAM_DEBUG_COMMAND, arg_bool)
+            pioneer.params.set_user_param(PARAM_DEBUG_COMMAND, arg_bool)
         elif cmd == "set_scan_interval":
             try:
                 scan_interval = float(arg)

--- a/aiopioneer/properties.py
+++ b/aiopioneer/properties.py
@@ -10,11 +10,11 @@ from .const import Zones, MEDIA_CONTROL_COMMANDS
 from .param import PioneerAVRParams, PARAM_ZONE_SOURCES, PARAM_QUERY_SOURCES
 
 
-class PioneerAVRProperties(PioneerAVRParams):
+class PioneerAVRProperties:
     """Pioneer AVR properties class."""
 
-    def __init__(self, params: dict[str, str] = None):
-        super().__init__(params)
+    def __init__(self, params: PioneerAVRParams):
+        self.params = params
 
         ## AVR base properties
         self.model = None
@@ -43,13 +43,13 @@ class PioneerAVRProperties(PioneerAVRParams):
 
     def set_source_dict(self, sources: dict[str, str]) -> None:
         """Manually set source id<->name translation tables."""
-        self.set_system_param(PARAM_QUERY_SOURCES, False)
+        self.params.set_system_param(PARAM_QUERY_SOURCES, False)
         self._source_name_to_id = copy.deepcopy(sources)
         self._source_id_to_name = {v: k for k, v in sources.items()}
 
     def get_source_list(self, zone: Zones = Zones.Z1) -> list[str]:
         """Return list of available input sources."""
-        source_ids = self._params.get(PARAM_ZONE_SOURCES[zone], [])
+        source_ids = self.params.get_param(PARAM_ZONE_SOURCES[zone], [])
         return list(
             self._source_name_to_id.keys()
             if not source_ids
@@ -64,7 +64,7 @@ class PioneerAVRProperties(PioneerAVRParams):
         """Return source id<->name translation tables."""
         if zone is None:
             return MappingProxyType(self._source_name_to_id)
-        source_ids = self._params.get(PARAM_ZONE_SOURCES[zone], [])
+        source_ids = self.params.get_param(PARAM_ZONE_SOURCES[zone], [])
         return (
             self._source_name_to_id
             if not source_ids

--- a/aiopioneer/properties.py
+++ b/aiopioneer/properties.py
@@ -18,6 +18,9 @@ class PioneerAVRProperties:
 
         ## AVR base properties
         self.model = None
+        self.software_version = None
+        self.mac_addr: str = None
+        self.zones: list[Zones] = []
         self.power: dict[Zones, bool] = {}
         self.volume: dict[Zones, int] = {}
         self.max_volume: dict[Zones, int] = {}
@@ -38,55 +41,55 @@ class PioneerAVRProperties:
         self.channel_levels: dict[str, Any] = {}
 
         ## Source name mappings
-        self._source_name_to_id: dict[str, str] = {}
-        self._source_id_to_name: dict[str, str] = {}
+        self.source_name_to_id: dict[str, str] = {}
+        self.source_id_to_name: dict[str, str] = {}
 
     def set_source_dict(self, sources: dict[str, str]) -> None:
         """Manually set source id<->name translation tables."""
         self.params.set_system_param(PARAM_QUERY_SOURCES, False)
-        self._source_name_to_id = copy.deepcopy(sources)
-        self._source_id_to_name = {v: k for k, v in sources.items()}
+        self.source_name_to_id = copy.deepcopy(sources)
+        self.source_id_to_name = {v: k for k, v in sources.items()}
 
     def get_source_list(self, zone: Zones = Zones.Z1) -> list[str]:
         """Return list of available input sources."""
         source_ids = self.params.get_param(PARAM_ZONE_SOURCES[zone], [])
         return list(
-            self._source_name_to_id.keys()
+            self.source_name_to_id.keys()
             if not source_ids
             else [
-                self._source_id_to_name[s]
+                self.source_id_to_name[s]
                 for s in source_ids
-                if s in self._source_id_to_name
+                if s in self.source_id_to_name
             ]
         )
 
     def get_source_dict(self, zone: Zones = None) -> dict[str, str]:
         """Return source id<->name translation tables."""
         if zone is None:
-            return MappingProxyType(self._source_name_to_id)
+            return MappingProxyType(self.source_name_to_id)
         source_ids = self.params.get_param(PARAM_ZONE_SOURCES[zone], [])
         return (
-            self._source_name_to_id
+            self.source_name_to_id
             if not source_ids
-            else {k: v for k, v in self._source_name_to_id.items() if v in source_ids}
+            else {k: v for k, v in self.source_name_to_id.items() if v in source_ids}
         )
 
     def get_source_name(self, source_id: str) -> str:
         """Return name for given source ID."""
         return (
-            self._source_id_to_name.get(source_id, source_id)
-            if self._source_name_to_id
+            self.source_id_to_name.get(source_id, source_id)
+            if self.source_name_to_id
             else source_id
         )
 
     def clear_source_id(self, source_id: str) -> None:
         """Clear name mapping for given source ID."""
         source_name = None
-        if source_id in self._source_id_to_name:
-            source_name = self._source_id_to_name[source_id]
-            self._source_id_to_name.pop(source_id)
-        if source_name in self._source_name_to_id:
-            self._source_name_to_id.pop(source_name)
+        if source_id in self.source_id_to_name:
+            source_name = self.source_id_to_name[source_id]
+            self.source_id_to_name.pop(source_id)
+        if source_name in self.source_name_to_id:
+            self.source_name_to_id.pop(source_name)
 
     def get_ipod_control_commands(self) -> list[str]:
         """Return a list of all valid iPod control modes."""

--- a/test_api.py
+++ b/test_api.py
@@ -39,11 +39,12 @@ async def main(argv):
 
     await pioneer.query_device_info()
     print(
-        f"AVR device info: model={pioneer.model}, "
-        + f"mac_addr={pioneer.mac_addr}, software_version={pioneer.software_version}"
+        f"AVR device info: model={pioneer.properties.model}, "
+        + f"mac_addr={pioneer.properties.mac_addr}, "
+        + f"software_version={pioneer.properties.software_version}"
     )
     await pioneer.query_zones()
-    print(f"AVR zones discovered: {pioneer.zones}")
+    print(f"AVR zones discovered: {pioneer.properties.zones}")
     print("Discovering zones")
     await pioneer.build_source_dict()
 


### PR DESCRIPTION
This change moves AVR properties into a separate class, which prevents non-AVR attributes in the main class from being inadvertently modified by parsers. Params are also moved into a separate class, which will allow parsers to access params.