### PR TITLE
Improve Exception Handling

### DIFF
--- a/aiopioneer/connection.py
+++ b/aiopioneer/connection.py
@@ -136,7 +136,7 @@ class PioneerAVRConnection:
         _LOGGER.debug(">> disconnect started")
 
         if not self.available:
-            _LOGGER.warning("AVR not connected, skipping disconnect")
+            _LOGGER.debug("AVR not connected, skipping disconnect")
             return
         if self._disconnect_lock.locked():
             raise RuntimeError("AVR connection is already disconnecting")
@@ -361,6 +361,7 @@ class PioneerAVRConnection:
             self._writer.write(command.encode("ASCII") + b"\r")
             await self._writer.drain()
         except Exception as exc:
+            _LOGGER.error("could not send command %s to AVR: %s", command, repr(exc))
             raise AVRUnavailableError from exc
         self._last_command_at = time.time()
 

--- a/aiopioneer/connection.py
+++ b/aiopioneer/connection.py
@@ -462,14 +462,15 @@ class PioneerAVRConnection:
                 return True
             raise AVRUnknownCommandError
 
-        if ignore_error is None:
-            ## Do not handle exceptions
-            return await _send_command()
-
         # pylint: disable=broad-exception-caught
         try:
             return await _send_command()
+        except AVRUnavailableError:  ## always raise even if ignoring errors
+            raise
         except (PioneerError, Exception) as exc:
+            if ignore_error is None:
+                _LOGGER.debug("send_command raised exception: %s", repr(exc))
+                raise
             translation_key = getattr(exc, "translation_key", "unknown_exception")
             err = PioneerErrorFormatText.get(translation_key, "unknown_exception")
             err_txt = err.format(command=command, zone=str(zone), exc=repr(exc))

--- a/aiopioneer/exceptions.py
+++ b/aiopioneer/exceptions.py
@@ -5,6 +5,12 @@ class PioneerError(RuntimeError):
     """Generic Pioneer AVR exception."""
 
 
+class AVRConnectError(PioneerError):
+    """Could not connect to AVR error."""
+
+    translation_key = "avr_connect_error"
+
+
 class AVRUnavailableError(PioneerError):
     """AVR connection not available exception."""
 
@@ -30,6 +36,7 @@ class AVRCommandError(PioneerError):
 
 
 PioneerErrorFormatText = {
+    "avr_connect_error": "Unable to connect to AVR",
     "avr_unavailable": "AVR connection is not available",
     "unknown_command": "Unknown AVR command {command} for zone {zone}",
     "response_timeout": "AVR command {command} timed out",

--- a/aiopioneer/exceptions.py
+++ b/aiopioneer/exceptions.py
@@ -1,26 +1,83 @@
 """ Pioneer AVR exceptions. """
 
+from .const import Zone
+
 
 class PioneerError(RuntimeError):
     """Generic Pioneer AVR exception."""
 
+    translation_key = None
 
-class AVRConnectError(PioneerError):
-    """Could not connect to AVR error."""
+    def __init__(self, msg: str = None, **kwargs):
+        self.kwargs = kwargs
+        if msg:
+            err_txt = msg
+        else:
+            err_key = self.translation_key
+            try:
+                err = ErrorFormatText[err_key]
+                err_txt = err.format(**self.kwargs)
+            except Exception as err_exc:  # pylint: disable=broad-except
+                err_txt = f"exception generating error {err_key}: {repr(err_exc)}"
+        super().__init__(err_txt)
+
+
+class AVRConnectionError(PioneerError):
+    """Could not connect to AVR."""
+
+    translation_key = "avr_connection_error"
+
+    def __init__(
+        self, err: str = None, err_key: str = None, exc: Exception = None, **kwargs
+    ):
+        if err_key:
+            err = ConnectErrorFormatText.get(err_key, err_key)
+        elif exc and err is None:
+            err = repr(exc)
+        super().__init__(err=err, exc=exc, **kwargs)
+
+
+class AVRConnectError(AVRConnectionError):
+    """Error with AVR connection."""
 
     translation_key = "avr_connect_error"
 
 
-class AVRUnavailableError(PioneerError):
-    """AVR connection not available exception."""
+class AVRConnectTimeoutError(AVRConnectError):
+    """Could not connect to AVR error due to a timeout."""
+
+    def __init__(self, exc: Exception = None, **kwargs):
+        super().__init__(err_key="connect_timeout_error", exc=exc, **kwargs)
+
+
+class AVRDisconnectError(AVRConnectionError):
+    """Error disconnecting from AVR."""
+
+    translation_key = "avr_disconnect_error"
+
+
+class AVRUnavailableError(AVRConnectionError):
+    """AVR connection not available."""
 
     translation_key = "avr_unavailable"
 
 
 class AVRUnknownCommandError(PioneerError):
-    """Invalid AVR command requested exception."""
+    """Invalid AVR command requested."""
 
     translation_key = "unknown_command"
+
+    def __init__(self, command: str, zone: Zone, **kwargs):
+        super().__init__(command=command, zone=zone, **kwargs)
+
+
+class AVRUnknownLocalCommandError(PioneerError):
+    """Invalid local command requested."""
+
+    translation_key = "unknown_local_command"
+
+    def __init__(self, command: str, **kwargs):
+        super().__init__(command=command, **kwargs)
 
 
 class AVRResponseTimeoutError(PioneerError):
@@ -28,18 +85,74 @@ class AVRResponseTimeoutError(PioneerError):
 
     translation_key = "response_timeout"
 
+    def __init__(self, command: str, **kwargs):
+        super().__init__(command=command, **kwargs)
+
 
 class AVRCommandError(PioneerError):
-    """AVR command returned an error."""
+    """AVR command resulted in an error."""
 
     translation_key = "command_error"
 
+    def __init__(self, command: str, err: str = None, exc: Exception = None, **kwargs):
+        if exc and err is None:
+            err = repr(exc)
+        super().__init__(command=command, err=err, exc=exc, **kwargs)
 
-PioneerErrorFormatText = {
-    "avr_connect_error": "Unable to connect to AVR",
+
+class AVRCommandResponseError(AVRCommandError):
+    """AVR responded with an error."""
+
+    def __init__(self, command: str, err: str, **kwargs):
+        super().__init__(command=command, err=err, **kwargs)
+
+
+class AVRLocalCommandError(AVRCommandError):
+    """Local command resulted in an error."""
+
+    translation_key = "local_command_error"
+
+    def __init__(
+        self,
+        command: str,
+        err: str = None,
+        err_key: str = None,
+        exc: Exception = None,
+        **kwargs,
+    ):
+        if err_key:
+            err = LocalCommandErrorFormatText.get(err_key, err_key)
+        elif exc and err is None:
+            err = repr(exc)
+        super().__init__(command=command, err=err, exc=exc, **kwargs)
+
+
+class AVRTunerUnavailableError(AVRLocalCommandError):
+    """Tuner is not available."""
+
+    def __init__(self, command: str, **kwargs):
+        super().__init__(command=command, err_key="tuner_unavailable", **kwargs)
+
+
+ErrorFormatText = {
+    "avr_connection_error": "AVR connection error: {err}",
+    "avr_connect_error": "Unable to connect to AVR: {err}",
+    "avr_disconnect_error": "Error disconnect from AVR: {err}",
     "avr_unavailable": "AVR connection is not available",
     "unknown_command": "Unknown AVR command {command} for zone {zone}",
+    "unknown_local_command": "Unknown command {command}",
     "response_timeout": "AVR command {command} timed out",
-    "command_error": "AVR command {command} returned error: {exc}",
-    "unknown_exception": "AVR command {command} returned exception: {exc}",
+    "command_error": "AVR command {command} returned error: {err}",
+    "local_command_error": "Command {command} error: {err}",
+}
+
+LocalCommandErrorFormatText = {
+    "tuner_unavailable": "AVR tuner is unavailable",
+}
+
+ConnectErrorFormatText = {
+    "connect_timeout_error": "Connection timed out",
+    "already_connected": "AVR is already connected",
+    "already_connecting": "AVR is already connecting",
+    "already_disconnecting": "AVR is already disconnecting",
 }

--- a/aiopioneer/pioneer_avr.py
+++ b/aiopioneer/pioneer_avr.py
@@ -488,6 +488,12 @@ class PioneerAVR(PioneerAVRConnection):
                         await local_command(command, args)
                     else:
                         await self.send_command(command, ignore_error=False)
+                except AVRUnavailableError:
+                    _LOGGER.debug(">> command queue detected AVR unavailable")
+                    break
+                except asyncio.CancelledError:
+                    _LOGGER.debug(">> command queue task cancelled")
+                    break
                 except Exception as exc:  # pylint: disable=broad-except
                     _LOGGER.error(
                         "exception executing command %s: %s", command, repr(exc)

--- a/aiopioneer/pioneer_avr.py
+++ b/aiopioneer/pioneer_avr.py
@@ -666,12 +666,12 @@ class PioneerAVR(PioneerAVRConnection):
     async def mute_on(self, zone: Zone = Zone.Z1) -> None:
         """Mute AVR."""
         zone = self._check_zone(zone)
-        await self.send_command("mute_on", zone, ignore_error=False)
+        await self.send_command("mute_on", zone)
 
     async def mute_off(self, zone: Zone = Zone.Z1) -> None:
         """Unmute AVR."""
         zone = self._check_zone(zone)
-        await self.send_command("mute_off", zone, ignore_error=False)
+        await self.send_command("mute_off", zone)
 
     async def select_listening_mode(
         self, mode_name: str = None, mode_id: str = None

--- a/aiopioneer/pioneer_avr.py
+++ b/aiopioneer/pioneer_avr.py
@@ -651,14 +651,14 @@ class PioneerAVR(PioneerAVRConnection):
                     if new_volume <= current_volume:  # going wrong way
                         raise AVRCommandError(
                             command="set_volume_level",
-                            zone=zone,
                             err="AVR volume_up failed",
+                            zone=zone,
                         )
                     if volume_step_count > (target_volume - start_volume):
                         raise AVRCommandError(
                             command="set_volume_level",
-                            zone=zone,
                             err="Exceeded max volume steps",
+                            zone=zone,
                         )
                     current_volume = new_volume
             elif target_volume < start_volume:  # step down
@@ -670,14 +670,14 @@ class PioneerAVR(PioneerAVRConnection):
                     if new_volume >= current_volume:  # going wrong way
                         raise AVRCommandError(
                             command="set_volume_level",
-                            zone=zone,
                             err="AVR volume_down failed",
+                            zone=zone,
                         )
                     if volume_step_count > (start_volume - target_volume):
                         raise AVRCommandError(
                             command="set_volume_level",
-                            zone=zone,
                             err="Exceeded max volume steps",
+                            zone=zone,
                         )
                     current_volume = self.properties.volume.get(zone.value)
         else:

--- a/aiopioneer/pioneer_avr.py
+++ b/aiopioneer/pioneer_avr.py
@@ -382,24 +382,21 @@ class PioneerAVR(PioneerAVRConnection):
         log_refresh = "refreshing AVR status (zones=%s, last updated %s)"
         _LOGGER.info(log_refresh, zones, last_updated_str)
         self.last_updated = time.time()
-        try:
-            for zone in zones:
-                await self._refresh_zone(zone)
-                zones_initial_refresh = self.params.zones_initial_refresh
-                if self.properties.power[zone] and zone not in zones_initial_refresh:
-                    if zone is Zone.Z1:
-                        await self.query_device_info()
-                    _LOGGER.info("completed initial refresh for %s", zone.full_name)
-                    zones_initial_refresh.add(zone)
-                    self.params.set_runtime_param(
-                        PARAM_ZONES_INITIAL_REFRESH, zones_initial_refresh
-                    )
-                    self._call_zone_callbacks(zones=set([zone]))
+        for zone in zones:
+            await self._refresh_zone(zone)
+            zones_initial_refresh = self.params.zones_initial_refresh
+            if self.properties.power[zone] and zone not in zones_initial_refresh:
+                if zone is Zone.Z1:
+                    await self.query_device_info()
+                _LOGGER.info("completed initial refresh for %s", zone.full_name)
+                zones_initial_refresh.add(zone)
+                self.params.set_runtime_param(
+                    PARAM_ZONES_INITIAL_REFRESH, zones_initial_refresh
+                )
+                self._call_zone_callbacks(zones=set([zone]))
 
-            ## Trigger callbacks to all zones on refresh
-            self._call_zone_callbacks(zones=set([Zone.ALL]))
-        except Exception as exc:  # pylint: disable=broad-except
-            _LOGGER.error("exception refreshing AVR status: %s", repr(exc))
+        ## Trigger callbacks to all zones on refresh
+        self._call_zone_callbacks(zones=set([Zone.ALL]))
 
         _LOGGER.debug(">> refresh completed")
 

--- a/aiopioneer/util.py
+++ b/aiopioneer/util.py
@@ -75,27 +75,6 @@ def get_backoff_delay(retry_count):
     return delay
 
 
-async def safe_wait_for(awt, timeout: float = None, name: str = None):
-    """
-    asyncio.wait_for() that re-raises cancellation even if aw is complete.
-    Work around issue: https://bugs.python.org/issue42130
-    """
-    task = asyncio.create_task(awt, name=name)
-    try:
-        await asyncio.wait({task}, timeout=timeout)
-        if task.done():
-            return task.result()
-        ## timed out
-        try:
-            task.cancel()
-            await task
-        except asyncio.CancelledError:
-            pass
-        raise TimeoutError()
-    except asyncio.CancelledError as exc:
-        raise exc
-
-
 async def cancel_task(task: asyncio.Task, debug=False, ignore_exception=False):
     """Cancels a task and waits for it to finish."""
     if not task:


### PR DESCRIPTION
* Exception handling has been overhauled:
  * More granular exception classes have been added as subclasses of PioneerError class
  * AVR errors for connection and update methods raise PioneerError subclasses when an AVR error is encountered.
  * `mute_on`, `mute_off`, `set_volume_level` now raises PioneerError subclasses for AVR errors, previously errors were only logged
  * `update` raises an ExceptionGroup when multiple exceptions are encountered during a full refresh
  * `update` raises `AVRUnavailableError` is raised when the AVR disconnects during a full refresh
  * `send_command` always raises `AVRUnavailableError` on AVR disconnect, even when `ignore_error` is set
  * Error text interpolation is moved into the PioneerError class
* The responder task has been removed and its functionality merged into the listener task. The responder debug parameter has also been removed
* AVR properties are reset to unknown on AVR disconnect. A full update after reconnection will repopulate AVR properties
