### PR TITLE
Update listening modes

### DIFF
--- a/README.md
+++ b/README.md
@@ -308,9 +308,9 @@ _awaitable_ `PioneerAVR.select_listening_mode(`_mode_name_: **str** = **None**, 
 Set the listening mode to name _mode_name_, or ID _mode_id_ (requires one argument.)
 Must be a listening mode valid for the current sound input as returned by `get_listening_modes`.
 
-`PioneerAVR.get_listening_modes()` -> **dict**[**str**, **str**] | **None**
+`PioneerAVR.get_listening_modes()` -> **list**[**str**] | **None**
 
-Return dict of valid listening mode mapping to names for the AVR.
+Return list of valid listening mode names for the AVR.
 
 _awaitable_ `PioneerAVR.set_volume_level(`_target_volume_: **int**, zone: Zones = Zones.Z1`)`
 

--- a/aiopioneer/pioneer_avr.py
+++ b/aiopioneer/pioneer_avr.py
@@ -629,9 +629,9 @@ class PioneerAVR(AVRConnection):
         """Unmute AVR."""
         await self.send_command("mute_off", zone=self._check_zone(zone))
 
-    def get_listening_modes(self) -> dict[str, str] | None:
-        """Return dict of valid listening modes and names for Zone 1."""
-        return self.properties.available_listening_modes.values()
+    def get_listening_modes(self) -> list[str] | None:
+        """Return list of valid listening modes and names for Zone 1."""
+        return list(self.properties.available_listening_modes.values())
 
     async def select_listening_mode(self, mode: str | int) -> None:
         """Set the listening mode using the predefined list of options in params."""


### PR DESCRIPTION
## Breaking Changes
* PioneerAVR.get_listening_modes now returns _list[str]_. This was changed in 0.9.0 but inadvertently omitted from the list of breaking changes

## All Changes
* Update get_listening_modes typing to return list
* Coerce get_listening_modes dict_values to list
* Update documentation for get_listening_modes
