### PR TITLE
Rename PioneerAVR.update to refresh

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,7 +135,7 @@ The CLI accepts all AVR commands, as well as the helper commands below. The `lis
 | `get_properties` | \[ `--zones` \]<br>\[ `--power` \]<br>\[ `--volume` \]<br>\[ `--max_volume` \]<br>\[ `--mute` \]<br>\[ `--source_id` \]<br>\[ `--source_name` \]<br>\[ `--media_control_mode` \]<br>\[ `--tone` \]<br>\[ `--amp` \]<br>\[ `--tuner` \]<br>\[ `--dsp` \]<br>\[ `--video` \]<br>\[ `--system` \]<br>\[ `--audio` \]<br>\[ `--channel_levels` \] | Show the current cached AVR properties for the specified property groups, or all property groups if none are specified
 | `get_scan_interval` | | Show the current scan interval.
 | `set_scan_interval` | _scan_interval_ (float) | Set the scan interval to _scan_interval_
-| `update` | [`--full`] | Refresh the cached AVR properties for the active zone, or all zones if `--full` is specified
+| `refresh` | [`--full`] | Refresh the cached AVR properties for the active zone, or all zones if `--full` is specified
 | `query_device_info` | | Query the AVR for device information
 | `query_zones` | | Query the AVR for available zones. Ignore zones specified in parameter `ignored_zones` (list)
 | `get_source_dict` | | Show the set of available source names and IDs that can be used with the `select_source` command

--- a/aiopioneer/cli.py
+++ b/aiopioneer/cli.py
@@ -145,7 +145,7 @@ class PioneerAVRCli(aioconsole.AsynchronousCli):
 
     async def avr_update(self, reader, writer, full: bool):
         """Refresh the cached AVR properties."""
-        await self.pioneer.update(None if full else self.zone)
+        await self.pioneer.refresh(None if full else self.zone)
 
     async def query_device_info(self, reader, writer) -> str:
         """Query the AVR for device information."""

--- a/aiopioneer/cli.py
+++ b/aiopioneer/cli.py
@@ -143,7 +143,7 @@ class PioneerAVRCli(aioconsole.AsynchronousCli):
         await self.pioneer.set_scan_interval(scan_interval)
         return await self.get_scan_interval(reader, writer)
 
-    async def avr_update(self, reader, writer, full: bool):
+    async def refresh(self, reader, writer, full: bool):
         """Refresh the cached AVR properties."""
         await self.pioneer.refresh(None if full else self.zone)
 
@@ -323,8 +323,8 @@ class PioneerAVRCli(aioconsole.AsynchronousCli):
         scan_interval_parser.add_argument(
             "scan_interval", type=float, help="scan interval"
         )
-        update_parser = get_command_parser(self.avr_update)
-        update_parser.add_argument("--full", "-f", action="store_true")
+        refresh_parser = get_command_parser(self.refresh)
+        refresh_parser.add_argument("--full", "-f", action="store_true")
         source_dict_parser = get_command_parser(self.set_source_dict)
         source_dict_parser.add_argument(
             "source_dict", type=source_json_arg, help="source dict (JSON)"
@@ -396,7 +396,7 @@ class PioneerAVRCli(aioconsole.AsynchronousCli):
             get_command(self.get_properties, parser=properties_parser),
             get_command(self.get_scan_interval),
             get_command(self.set_scan_interval, parser=scan_interval_parser),
-            get_command(self.avr_update, "update", update_parser),
+            get_command(self.refresh, refresh_parser),
             get_command(self.query_device_info),
             get_command(self.query_zones),
             get_command(self.get_source_dict),

--- a/aiopioneer/pioneer_avr.py
+++ b/aiopioneer/pioneer_avr.py
@@ -107,7 +107,7 @@ class PioneerAVR(AVRConnection):
     async def on_reconnect(self) -> None:
         """Update AVR on reconnection."""
         await super().on_reconnect()
-        await self.update(wait=False)
+        await self.refresh(wait=False)
 
     async def on_disconnect(self) -> None:
         """Stop AVR tasks on disconnection."""
@@ -384,10 +384,10 @@ class PioneerAVR(AVRConnection):
         self._call_zone_callbacks(zones=set([Zone.ALL]))
         _LOGGER.debug(">> full refresh completed")
 
-    async def update(
+    async def refresh(
         self, zones: list[Zone] | set[Zone] | Zone = None, wait: bool = True
     ) -> None:
-        """Update AVR cached status."""
+        """Refresh AVR cached properties."""
         if isinstance(zones, Zone):
             zones = {zones}
         if isinstance(zones, list):

--- a/python_api.md
+++ b/python_api.md
@@ -36,9 +36,9 @@ Number of seconds between polls for AVR full updates.
 
 ## Update methods
 
-_awaitable_ `PioneerAVR.update(`_zones_: **list[Zone]** = **None**, _wait_: **bool** = **True**`)`
+_awaitable_ `PioneerAVR.refresh(`_zones_: **list[Zone]** = **None**, _wait_: **bool** = **True**`)`
 
-Update of the cached properties from the AVR via the command queue. <br/>
+Refresh the cached properties from the AVR via the command queue. <br/>
 Refresh the AVR zones _zones_, or all AVR zones if not specified. <br/>
 Wait for the update to be completed if _wait_ is **True**. <br/>
 

--- a/test_api.py
+++ b/test_api.py
@@ -49,7 +49,7 @@ async def main(argv):
     print("Discovering zones")
     await pioneer.build_source_dict()
 
-    await pioneer.update()
+    await pioneer.refresh()
     await asyncio.sleep(15)
     ## Turn on main zone for tests
     await pioneer.power_on(zone=Zone.Z1)
@@ -68,7 +68,7 @@ async def main(argv):
 
         await asyncio.sleep(60)
         print("Update ...")
-        await pioneer.update()
+        await pioneer.refresh()
 
     # await pioneer.send_raw_request("?RGD", "RGD", ignore_error=True)
     # print("...")


### PR DESCRIPTION
## Breaking Changes
* The `PioneerAVR.update` method has been renamed to `refresh` to better reflect what it does
* The `update` CLI command has also been renamed to `refresh` to match the method