### PR TITLE
Tuner code map updates

### DIFF
--- a/aiopioneer/decoders/tuner.py
+++ b/aiopioneer/decoders/tuner.py
@@ -249,14 +249,8 @@ COMMANDS_TUNER = {
     },
     "tuner_next_preset": {Zone.Z1: ["TPI", "PR"]},
     "tuner_previous_preset": {Zone.Z1: ["TPD", "PR"]},
-    "set_tuner_band_am": {
-        Zone.Z1: ["01TN", "FR"],
-        "retry_on_fail": True,
-    },
-    "set_tuner_band_fm": {
-        Zone.Z1: ["00TN", "FR"],
-        "retry_on_fail": True,
-    },
+    "tuner_band_am": {Zone.Z1: ["01TN", "FR"], "retry_on_fail": True},
+    "tuner_band_fm": {Zone.Z1: ["00TN", "FR"], "retry_on_fail": True},
     "tuner_increase_frequency": {Zone.Z1: ["TFI", "FR"]},
     "tuner_decrease_frequency": {Zone.Z1: ["TFD", "FR"]},
     "tuner_direct_access": {Zone.Z1: ["TAC", "TAC"]},

--- a/aiopioneer/pioneer_avr.py
+++ b/aiopioneer/pioneer_avr.py
@@ -684,10 +684,7 @@ class PioneerAVR(AVRConnection):
         ## Set the tuner band
         if band == self.properties.tuner.get("band"):
             return
-        tuner_commands = {
-            TunerBand.AM: "set_tuner_band_am",
-            TunerBand.FM: "set_tuner_band_fm",
-        }
+        tuner_commands = {TunerBand.AM: "tuner_band_am", TunerBand.FM: "tuner_band_fm"}
         await self.send_command(tuner_commands[band])
 
     async def _calculate_am_frequency_step(self) -> None:

--- a/aiopioneer/pioneer_avr.py
+++ b/aiopioneer/pioneer_avr.py
@@ -779,10 +779,8 @@ class PioneerAVR(AVRConnection):
         if await self.send_command("tuner_direct_access", ignore_error=True):
             ## Set tuner frequency directly if command is supported
             try:
-                for digit in code:
-                    await self.send_command(
-                        "tuner_digit", prefix=digit, rate_limit=False
-                    )
+                for digit in code.lstrip("0"):
+                    await self.send_command("tuner_digit", prefix=digit)
             except AVRCommandError as exc:
                 raise AVRLocalCommandError(
                     command=command, err_key="freq_set_failed", exc=exc


### PR DESCRIPTION
## Breaking Changes 
* AVR commands `set_tuner_band_am` and `set_tuner_band_fm` have been renamed to `tuner_band_am` and `tuner_band_fm` respectively to be consistent with other operational commands