### PR TITLE
Queue refresh commands

### DIFF
--- a/aiopioneer/decoders/amp.py
+++ b/aiopioneer/decoders/amp.py
@@ -53,14 +53,19 @@ class Power(CodeInverseBoolMap):
             if zone not in properties.zones_initial_refresh:
                 _LOGGER.info("queueing initial refresh for %s", zone.full_name)
                 queue_commands.append(
-                    CommandItem("_delayed_refresh_zone", zone, queue_id=2),
+                    CommandItem(
+                        "_delayed_refresh_zone",
+                        zone,
+                        queue_id=2,
+                        skip_if_refreshing=True,
+                    ),
                 )
-            elif properties.power.get(zone):  ## zone is already on
+            if properties.power.get(zone) is not False:  ## zone is not off
                 return []
 
             if zone is Zone.Z1 and params.get_param(PARAM_POWER_ON_VOLUME_BOUNCE):
                 _LOGGER.info("queueing volume workaround for Main Zone")
-                ## NOTE: volume bounce queues before refresh
+                ## NOTE: volume bounce queues ahead of refresh
                 queue_commands.extend(
                     [
                         CommandItem("volume_up", queue_id=0, skip_if_queued=False),

--- a/aiopioneer/decoders/tuner.py
+++ b/aiopioneer/decoders/tuner.py
@@ -231,9 +231,7 @@ class Preset(CodeStrMap):
         super().decode_response(response=response, params=params)
         response.update(
             clear_property=True,
-            queue_commands=[
-                CommandItem("query_tuner_frequency", skip_if_executing=True)
-            ],
+            queue_commands=[CommandItem("query_tuner_frequency")],
             callback=cache_preset,
         )
         return [response]

--- a/python_api.md
+++ b/python_api.md
@@ -1,3 +1,4 @@
+<!-- markdownlint-disable no-inline-html -->
 # Python API
 
 The library exposes a Python API through the **PioneerAVR** class. The class methods are listed below:
@@ -113,15 +114,15 @@ If _source_name_ is **None**, reset source name to default.
 
 ## Command queue methods
 
-`CommandQueue.enqueue(`_item_: **ComandItem**, _queue_id_: **int** = **None**, _skip_if_startup_: **bool** = **None**, _skip_if_queued_: **bool** = **None**, _skip_if_executing_: **bool** = **None**, _insert_at_: **int** = -1, _start_executing_: **bool** = **True**`)` -> **None**
+`CommandQueue.enqueue(`_item_: **ComandItem**, _queue_id_: **int** = **None**, _skip_if_startup_: **bool** = **None**, _skip_if_queued_: **bool** = **None**, _skip_if_refreshing_: **bool** = **None**, _insert_at_: **int** = -1, _start_executing_: **bool** = **True**`)` -> **None**
 
 Add _item_ to the command queue, to be sent in the background to the AVR or executed as a local command. <br/>
 Use the queue _queue_id_ if specified, otherwise use the default queue. <br/>
 Insert at position _insert_at_ in the queue. If _insert_at_ is negative, then calculate the position relative to the end of the queue. If not specified, use the value specified in _item_. <br/>
-If _skip_if_startup_, _skip_if_queued_ and/or _skip_if_executing_ are provided, then override the values specified in _item_. <br/>
+If _skip_if_startup_, _skip_if_queued_ and/or _skip_if_refreshing_ are provided, then override the values specified in _item_. <br/>
 If _skip_if_startup_ is **True**, then the command is not queued if the module is still connecting to the AVR. <br/>
 If _skip_if_queued_ is **True** and _item_ is already present in the command queue, then the command is not queued again. <br/>
-If _skip_if_executing_ is **True**, then the command is not queued if the command queue is currently executing. <br/>
+If _skip_if_refreshing_ is **True**, then the command is not queued if the zone is scheduled for a refresh. <br/>
 If _start_executing_ is **True**, then starts the command queue task if it is not already running. <br/>
 
 The following local commands are supported, these are mainly used by the command decoders for more complex actions:


### PR DESCRIPTION
## What's Changed
* Commands executed for a zone refresh are now scheduled on the command queue
* The enabled functions configured in PARAM_INITIAL_REFRESH_FUNCTIONS are now run only on initial refresh
* Initial refreshes for a zone are not scheduled if the zone is already pending a refresh

## Breaking Changes
* CommandItem constructor arguments have been renamed:
  * `skip_if_startup` has been renamed `skip_if_starting`
  * `skip_if_executing` has been repurposed as `skip_if_refreshing` and skips queuing the command if a pending refresh has been set for the zone
