### PR TITLE
Add code map properties for HA

### DIFF
--- a/aiopioneer/decoders/amp.py
+++ b/aiopioneer/decoders/amp.py
@@ -635,7 +635,7 @@ PROPERTIES_AMP = [
         SourceName,
         {Zone.ALL: "RGB"},
         query_command=AVRCommand(
-            avr_args=[CodeMapBlank(), SourceId],
+            avr_args=[CodeMapQuery(CodeMapBlank), SourceId],
             is_query_command=True,
             wait_for_response=True,
         ),

--- a/aiopioneer/decoders/amp.py
+++ b/aiopioneer/decoders/amp.py
@@ -14,6 +14,7 @@ from ..params import (
 from ..properties import AVRProperties
 from ..property_entry import AVRCommand, gen_query_property, gen_set_property
 from .code_map import (
+    CodeMapQuery,
     CodeMapBlank,
     CodeMapHasPropertyMixin,
     CodeBoolMap,
@@ -98,7 +99,7 @@ class Power(CodeInverseBoolMap):
 
 
 class Volume(CodeIntMap):
-    """Zone volume. (1step = 0.5dB for Main Zone, 1step = 1.0dB for other zones)"""
+    """Zone volume (1step = 0.5dB for Main Zone, 1step = 1.0dB for other zones)."""
 
     friendly_name = "volume"
     base_property = "volume"
@@ -319,47 +320,58 @@ class SpeakerMode(CodeMapHasPropertyMixin, CodeDictStrMap):
     friendly_name = "speaker mode"
     base_property = "amp"
     property_name = "speaker_mode"
+    supported_zones = (Zone.ALL,)
+    icon = "mdi:speaker-multiple"
+    ha_enable_default = True
 
     code_map = {"0": "off", "1": "A", "2": "B", "3": "A+B"}
 
 
-class HdmiOut(CodeMapHasPropertyMixin, CodeDictStrMap):
+class HDMIOut(CodeMapHasPropertyMixin, CodeDictStrMap):
     """HDMI out."""
 
     friendly_name = "HDMI out"
     base_property = "amp"
     property_name = "hdmi_out"
+    supported_zones = (Zone.ALL,)
+    icon = "mdi:monitor-share"
 
     code_map = {"0": "all", "1": "HDMI 1", "2": "HDMI 2"}
 
 
-class Hdmi3Out(CodeMapHasPropertyMixin, CodeBoolMap):
+class HDMI3Out(CodeMapHasPropertyMixin, CodeBoolMap):
     """HDMI3 out."""
 
     friendly_name = "HDMI3 out"
     base_property = "amp"
     property_name = "hdmi3_out"
+    supported_zones = (Zone.ALL,)
+    icon = "mdi:monitor-share"
 
     code_true = "1"
     code_false = "3"
 
 
-class HdmiAudio(CodeMapHasPropertyMixin, CodeDictStrMap):
+class HDMIAudio(CodeMapHasPropertyMixin, CodeDictStrMap):
     """HDMI audio."""
 
     friendly_name = "HDMI audio"
     base_property = "amp"
     property_name = "hdmi_audio"
+    supported_zones = (Zone.ALL,)
+    icon = "mdi:television-speaker"
 
     code_map = {"0": "amp", "1": "passthrough"}
 
 
-class Pqls(CodeMapHasPropertyMixin, CodeDictStrMap):
+class PQLS(CodeMapHasPropertyMixin, CodeDictStrMap):
     """PQLS."""
 
     friendly_name = "PQLS"
     base_property = "amp"
     property_name = "pqls"
+    supported_zones = (Zone.ALL,)
+    icon = "mdi:surround-sound"
 
     code_map = {"0": "off", "1": "auto"}
 
@@ -389,6 +401,9 @@ class Dimmer(CodeDictStrMap):
     friendly_name = "dimmer"
     base_property = "amp"
     property_name = "dimmer"
+    supported_zones = (Zone.ALL,)
+    icon = "mdi:white-balance-iridescent"
+    ha_enable_default = True
 
     code_map = {
         "0": "brightest",
@@ -404,6 +419,12 @@ class SleepTime(CodeIntMap):
     friendly_name = "sleep time"
     base_property = "amp"
     property_name = "sleep_time"
+    supported_zones = (Zone.ALL,)
+    icon = "mdi:timer-pause-outline"
+    unit_of_measurement = "s"
+    ha_enable_default = True
+    ha_device_class = "duration"
+    ha_number_mode = "slider"
 
     value_min = 0
     value_max = 90
@@ -417,6 +438,9 @@ class AmpMode(CodeMapHasPropertyMixin, CodeDictStrMap):
     friendly_name = "AMP status"
     base_property = "amp"
     property_name = "mode"
+    supported_zones = (Zone.ALL,)
+    icon = "mdi:audio-video"
+    ha_enable_default = True
 
     code_map = {
         "0": "amp on",
@@ -432,6 +456,9 @@ class PanelLock(CodeDictStrMap):
     friendly_name = "panel lock"
     base_property = "amp"
     property_name = "panel_lock"
+    supported_zones = (Zone.ALL,)
+    icon = "mdi:monitor-lock"
+    ha_enable_default = True
 
     code_map = {"0": "off", "1": "panel only", "2": "panel + volume"}
 
@@ -442,6 +469,9 @@ class RemoteLock(CodeBoolMap):
     friendly_name = "remote lock"
     base_property = "amp"
     property_name = "remote_lock"
+    supported_zones = (Zone.ALL,)
+    icon = "mdi:lan-disconnect"
+    ha_enable_default = True
 
 
 class SystemMacAddress(CodeStrMap):
@@ -625,10 +655,10 @@ PROPERTIES_AMP = [
         ],
     ),
     gen_set_property(SpeakerMode, {Zone.ALL: "SPK"}),
-    gen_set_property(HdmiOut, {Zone.ALL: "HO"}),
-    gen_set_property(Hdmi3Out, {Zone.ALL: "HDO"}),
-    gen_set_property(HdmiAudio, {Zone.ALL: "HA"}),
-    gen_set_property(Pqls, {Zone.ALL: "PQ"}),
+    gen_set_property(HDMIOut, {Zone.ALL: "HO"}),
+    gen_set_property(HDMI3Out, {Zone.ALL: "HDO"}),
+    gen_set_property(HDMIAudio, {Zone.ALL: "HA"}),
+    gen_set_property(PQLS, {Zone.ALL: "PQ"}),
     gen_query_property(
         DisplayText, {Zone.ALL: "FL"}, query_command="query_display_information"
     ),

--- a/aiopioneer/decoders/audio.py
+++ b/aiopioneer/decoders/audio.py
@@ -293,7 +293,7 @@ class AudioInformation(CodeMapSequence):
 
 
 class ChannelLevel(CodeFloatMap):
-    """Channel level. (1step=0.5dB)"""
+    """Channel level (1step = 0.5dB)."""
 
     friendly_name = "channel level"
 
@@ -303,6 +303,13 @@ class ChannelLevel(CodeFloatMap):
     value_divider = 0.5
     value_offset = 25
     code_zfill = 2
+    icon = "mdi:tune-vertical-variant"
+    supported_zones = (Zone.Z1, Zone.Z2, Zone.Z3)
+    unit_of_measurement = "dB"
+    ha_auto_entity = False
+    ha_enable_default = True
+    ha_device_class = "signal_strength"
+    ha_number_mode = "slider"
 
 
 class SpeakerChannel(CodeStrMap):
@@ -485,6 +492,9 @@ class ToneMode(CodeDictStrMap):
     friendly_name = "channel level"
     base_property = "tone"
     property_name = "status"
+    supported_zones = (Zone.Z1, Zone.Z2)
+    icon = "mdi:music-box-outline"
+    ha_enable_default = True
 
     code_map = {"0": "bypass", "1": "on"}
 
@@ -497,6 +507,12 @@ class ToneDb(CodeIntMap):
     value_divider = -1
     value_offset = -6
     code_zfill = 2
+    supported_zones = (Zone.Z1, Zone.Z2)
+    unit_of_measurement = "dB"
+    ha_auto_entity = False
+    ha_enable_default = True
+    ha_device_class = "signal_strength"
+    ha_number_mode = "slider"
 
 
 class ToneBass(ToneDb):
@@ -505,6 +521,7 @@ class ToneBass(ToneDb):
     friendly_name = "tone bass"
     base_property = "tone"
     property_name = "bass"
+    icon = "mdi:music-clef-bass"
 
 
 class ToneTreble(ToneDb):
@@ -513,6 +530,7 @@ class ToneTreble(ToneDb):
     friendly_name = "tone treble"
     base_property = "tone"
     property_name = "treble"
+    icon = "mdi:music-clef-treble"
 
 
 PROPERTIES_AUDIO = [

--- a/aiopioneer/decoders/code_map.py
+++ b/aiopioneer/decoders/code_map.py
@@ -4,7 +4,7 @@ import argparse
 import logging
 import re
 from abc import abstractmethod
-from typing import Any, Tuple
+from typing import Any
 
 from ..const import Zone
 from ..exceptions import AVRCommandUnavailableError
@@ -31,10 +31,13 @@ class CodeDefault:
 class CodeMapBase:
     """Map AVR codes to values."""
 
-    friendly_name = None
-    base_property = None
-    property_name = None
-    icon = "mdi:audio-video"
+    friendly_name: str = None
+    base_property: str = None
+    property_name: str = None
+    supported_zones: tuple[Zone, ...] = ()
+    icon: str = "mdi:audio-video"
+    ha_auto_entity: bool = True  ## add as HA entity automatically
+    ha_enable_default: bool = False  ## enable entity by default
 
     def __new__(cls, value, **kwargs):
         _LOGGER.warning("deprecated __new__ method called for class %s", cls)
@@ -643,7 +646,7 @@ class CodeDictListMap(CodeDictMap):
     code_map: dict[str, list] = {}
 
     @classmethod
-    def code_to_value(cls, code: str) -> Tuple[str, list]:
+    def code_to_value(cls, code: str) -> tuple[str, list]:
         value_list = super().code_to_value(code=code)
         return value_list[0]
 

--- a/aiopioneer/decoders/code_map.py
+++ b/aiopioneer/decoders/code_map.py
@@ -681,6 +681,9 @@ class CodeFloatMap(CodeMapBase):
     value_step: float | int = 1
     value_divider: float | int = 1
     value_offset: float | int = 0
+    unit_of_measurement: str = None
+    ha_device_class: str = None  ## integration default
+    ha_number_mode: str = None  ## integration default
 
     @classmethod
     def get_len(cls) -> int:

--- a/aiopioneer/decoders/dsp.py
+++ b/aiopioneer/decoders/dsp.py
@@ -332,6 +332,9 @@ class SACDGain(CodeIntMap):
     ha_device_class = "signal_strength"
     ha_number_mode = "slider"
 
+    value_min = 0
+    value_max = 6
+    value_step = 6
     code_zfill = 1
 
     @classmethod

--- a/aiopioneer/decoders/dsp.py
+++ b/aiopioneer/decoders/dsp.py
@@ -28,16 +28,23 @@ class PhaseControl(CodeDictStrMap):
     friendly_name = "phase control"
     base_property = "dsp"
     property_name = "phase_control"
+    supported_zones = (Zone.ALL,)
+    icon = "mdi:equalizer"
 
     code_map = {"0": "off", "1": "on", "2": "full band on"}
 
 
 class PhaseControlPlus(CodeIntMap):
-    """Phase control plus. (1step = 1ms)"""
+    """Phase control plus (1step = 1ms)."""
 
     friendly_name = "phase control plus"
     base_property = "dsp"
     property_name = "phase_control_plus"
+    supported_zones = (Zone.ALL,)
+    icon = "mdi:equalizer"
+    unit_of_measurement = "ms"
+    ha_device_class = "duration"
+    ha_number_mode = "slider"
 
     value_min = 0
     value_max = 16
@@ -62,6 +69,8 @@ class VirtualSpeakers(CodeDictStrMap):
     friendly_name = "virtual speakers"
     base_property = "dsp"
     property_name = "virtual_speakers"
+    supported_zones = (Zone.ALL,)
+    icon = "mdi:speaker-multiple"
 
     code_map = {"0": "auto", "1": "manual"}
 
@@ -72,6 +81,8 @@ class VirtualSoundback(CodeBoolMap):
     friendly_name = "virtual soundback"
     base_property = "dsp"
     property_name = "virtual_sb"  # NOTE: inconsistent
+    supported_zones = (Zone.ALL,)
+    icon = "mdi:equalizer"
 
 
 class VirtualHeight(CodeBoolMap):
@@ -80,6 +91,8 @@ class VirtualHeight(CodeBoolMap):
     friendly_name = "virtual height"
     base_property = "dsp"
     property_name = "virtual_height"
+    supported_zones = (Zone.ALL,)
+    icon = "mdi:equalizer"
 
 
 class VirtualWide(CodeBoolMap):
@@ -88,6 +101,8 @@ class VirtualWide(CodeBoolMap):
     friendly_name = "virtual wide"
     base_property = "dsp"
     property_name = "virtual_wide"
+    supported_zones = (Zone.ALL,)
+    icon = "mdi:equalizer"
 
 
 class VirtualDepth(CodeDictStrMap):
@@ -96,6 +111,8 @@ class VirtualDepth(CodeDictStrMap):
     friendly_name = "virtual depth"
     base_property = "dsp"
     property_name = "virtual_depth"
+    supported_zones = (Zone.ALL,)
+    icon = "mdi:equalizer"
 
     code_map = {"0": "off", "1": "min", "2": "mid", "3": "max"}
 
@@ -106,6 +123,8 @@ class SoundRetriever(CodeBoolMap):
     friendly_name = "sound retriever"
     base_property = "dsp"
     property_name = "sound_retriever"
+    supported_zones = (Zone.ALL,)
+    icon = "mdi:equalizer"
 
 
 class SignalSelect(CodeDictStrMap):
@@ -114,6 +133,8 @@ class SignalSelect(CodeDictStrMap):
     friendly_name = "signal select"
     base_property = "dsp"
     property_name = "signal_select"
+    supported_zones = (Zone.ALL,)
+    icon = "mdi:equalizer"
 
     code_map = {"0": "auto", "1": "analog", "2": "digital", "3": "HDMI"}
 
@@ -124,6 +145,8 @@ class InputAttenuator(CodeBoolMap):
     friendly_name = "input attenuator"
     base_property = "dsp"
     property_name = "input_attenuator"
+    supported_zones = (Zone.ALL,)
+    icon = "mdi:equalizer"
 
 
 class Equalizer(CodeBoolMap):
@@ -132,6 +155,8 @@ class Equalizer(CodeBoolMap):
     friendly_name = "equalizer"
     base_property = "dsp"
     property_name = "eq"
+    supported_zones = (Zone.ALL,)
+    icon = "mdi:equalizer"
 
 
 class StandingWave(CodeBoolMap):
@@ -140,14 +165,21 @@ class StandingWave(CodeBoolMap):
     friendly_name = "standing wave"
     base_property = "dsp"
     property_name = "standing_wave"
+    supported_zones = (Zone.ALL,)
+    icon = "mdi:equalizer"
 
 
 class SoundDelay(CodeIntMap):
-    """Sound delay. (1step=5ms)"""
+    """Sound delay (1step = 5ms)."""
 
     friendly_name = "sound delay"
     base_property = "dsp"
     property_name = "sound_delay"
+    supported_zones = (Zone.ALL,)
+    icon = "mdi:equalizer"
+    unit_of_measurement = "ms"
+    ha_device_class = "duration"
+    ha_number_mode = "slider"
 
     value_min = 0
     value_max = 800
@@ -162,6 +194,8 @@ class DigitalNoiseReduction(CodeBoolMap):
     friendly_name = "digital noise reduction"
     base_property = "dsp"
     property_name = "digital_noise_reduction"
+    supported_zones = (Zone.ALL,)
+    icon = "mdi:equalizer"
 
 
 class DialogEnhancement(CodeDictStrMap):
@@ -170,6 +204,8 @@ class DialogEnhancement(CodeDictStrMap):
     friendly_name = "dialog enhancement"
     base_property = "dsp"
     property_name = "dialog_enhancement"
+    supported_zones = (Zone.ALL,)
+    icon = "mdi:equalizer"
 
     code_map = {"0": "off", "1": "flat", "2": "+1", "3": "+2", "4": "+3", "5": "+4"}
 
@@ -180,6 +216,8 @@ class AudioScaler(CodeDictStrMap):
     friendly_name = "audio scaler"
     base_property = "dsp"
     property_name = "audio_scaler"
+    supported_zones = (Zone.ALL,)
+    icon = "mdi:equalizer"
 
     code_map = {"0": "auto", "1": "manual"}
 
@@ -190,6 +228,8 @@ class HiBit(CodeBoolMap):
     friendly_name = "hi-bit"
     base_property = "dsp"
     property_name = "hi_bit"
+    supported_zones = (Zone.ALL,)
+    icon = "mdi:equalizer"
 
 
 class UpSampling(CodeDictStrMap):
@@ -198,6 +238,8 @@ class UpSampling(CodeDictStrMap):
     friendly_name = "up sampling"
     base_property = "dsp"
     property_name = "up_sampling"
+    supported_zones = (Zone.ALL,)
+    icon = "mdi:equalizer"
 
     code_map = {"0": "off", "1": "2 times", "2": "4 times"}
 
@@ -208,6 +250,8 @@ class DigitalFilter(CodeDictStrMap):
     friendly_name = "digital filter"
     base_property = "dsp"
     property_name = "digital_filter"
+    supported_zones = (Zone.ALL,)
+    icon = "mdi:equalizer"
 
     code_map = {"0": "slow", "1": "sharp", "2": "short"}
 
@@ -218,16 +262,20 @@ class DualMono(CodeDictStrMap):
     friendly_name = "dual mono"
     base_property = "dsp"
     property_name = "dual_mono"
+    supported_zones = (Zone.ALL,)
+    icon = "mdi:equalizer"
 
     code_map = {"0": "CH1+CH2", "1": "CH1", "2": "CH2"}
 
 
-class FixedPcm(CodeBoolMap):
+class FixedPCM(CodeBoolMap):
     """Fixed PCM."""
 
     friendly_name = "fixed PCM"
     base_property = "dsp"
     property_name = "fixed_pcm"
+    supported_zones = (Zone.ALL,)
+    icon = "mdi:equalizer"
 
 
 class DynamicRange(CodeDictStrMap):
@@ -236,16 +284,23 @@ class DynamicRange(CodeDictStrMap):
     friendly_name = "dynamic range"
     base_property = "dsp"
     property_name = "dynamic_range"
+    supported_zones = (Zone.ALL,)
+    icon = "mdi:equalizer"
 
     code_map = {"0": "off", "1": "auto", "2": "mid", "3": "max"}
 
 
-class LfeAttenuator(CodeIntMap):
+class LFEAttenuator(CodeIntMap):
     """LFE attenuator."""
 
     friendly_name = "LFE attenuator"
     base_property = "dsp"
     property_name = "lfe_attenuator"
+    supported_zones = (Zone.ALL,)
+    icon = "mdi:equalizer"
+    unit_of_measurement = "dB"
+    ha_device_class = "signal_strength"
+    ha_number_mode = "slider"
 
     value_min = -20
     value_max = 0
@@ -265,12 +320,17 @@ class LfeAttenuator(CodeIntMap):
         return super().code_to_value(code=code)
 
 
-class SacdGain(CodeIntMap):
+class SACDGain(CodeIntMap):
     """SACD gain."""
 
     friendly_name = "SACD gain"
     base_property = "dsp"
     property_name = "sacd_gain"
+    supported_zones = (Zone.ALL,)
+    icon = "mdi:equalizer"
+    unit_of_measurement = "dB"
+    ha_device_class = "signal_strength"
+    ha_number_mode = "slider"
 
     code_zfill = 1
 
@@ -291,6 +351,8 @@ class AutoDelay(CodeBoolMap):
     friendly_name = "auto delay"
     base_property = "dsp"
     property_name = "auto_delay"
+    supported_zones = (Zone.ALL,)
+    icon = "mdi:equalizer"
 
 
 class CenterWidth(CodeIntMap):
@@ -299,6 +361,9 @@ class CenterWidth(CodeIntMap):
     friendly_name = "center width"
     base_property = "dsp"
     property_name = "center_width"
+    supported_zones = (Zone.ALL,)
+    icon = "mdi:equalizer"
+    ha_number_mode = "slider"
 
     value_min = 0
     value_max = 7
@@ -311,6 +376,8 @@ class Panorama(CodeBoolMap):
     friendly_name = "panorama"
     base_property = "dsp"
     property_name = "panorama"
+    supported_zones = (Zone.ALL,)
+    icon = "mdi:equalizer"
 
 
 class Dimension(CodeIntMap):
@@ -319,6 +386,9 @@ class Dimension(CodeIntMap):
     friendly_name = "dimension"
     base_property = "dsp"
     property_name = "dimension"
+    supported_zones = (Zone.ALL,)
+    icon = "mdi:equalizer"
+    ha_number_mode = "slider"
 
     value_min = -3
     value_max = 3
@@ -327,11 +397,14 @@ class Dimension(CodeIntMap):
 
 
 class CenterImage(CodeFloatMap):
-    """Center image. (1step=0.1)"""
+    """Center image (1step = 0.1)."""
 
     friendly_name = "center image"
     base_property = "dsp"
     property_name = "center_image"
+    supported_zones = (Zone.ALL,)
+    icon = "mdi:equalizer"
+    ha_number_mode = "slider"
 
     value_min = 0
     value_max = 1
@@ -341,11 +414,14 @@ class CenterImage(CodeFloatMap):
 
 
 class Effect(CodeIntMap):
-    """Effect. (1step=10)"""
+    """Effect (1step = 10)."""
 
     friendly_name = "effect"
     base_property = "dsp"
     property_name = "effect"
+    supported_zones = (Zone.ALL,)
+    icon = "mdi:equalizer"
+    ha_number_mode = "slider"
 
     value_min = 10
     value_max = 90
@@ -360,6 +436,8 @@ class HeightGain(CodeDictStrMap):
     friendly_name = "height gain"
     base_property = "dsp"
     property_name = "height_gain"
+    supported_zones = (Zone.ALL,)
+    icon = "mdi:equalizer"
 
     code_map = {"0": "low", "1": "mid", "2": "high"}
 
@@ -370,6 +448,8 @@ class LoudnessManagement(CodeBoolMap):
     friendly_name = "loudness management"
     base_property = "dsp"
     property_name = "loudness_management"
+    supported_zones = (Zone.ALL,)
+    icon = "mdi:equalizer"
 
 
 class CenterSpread(CodeBoolMap):
@@ -378,6 +458,8 @@ class CenterSpread(CodeBoolMap):
     friendly_name = "center spread"
     base_property = "dsp"
     property_name = "center_spread"
+    supported_zones = (Zone.ALL,)
+    icon = "mdi:equalizer"
 
 
 class RenderingMode(CodeDictStrMap):
@@ -386,6 +468,8 @@ class RenderingMode(CodeDictStrMap):
     friendly_name = "rendering mode"
     base_property = "dsp"
     property_name = "rendering_mode"
+    supported_zones = (Zone.ALL,)
+    icon = "mdi:equalizer"
 
     code_map = {"0": "object base", "1": "channel base"}
 
@@ -412,10 +496,10 @@ PROPERTIES_DSP = [
     gen_set_property(UpSampling, {Zone.ALL: "ATZ"}),
     gen_set_property(DigitalFilter, {Zone.ALL: "ATV"}),
     gen_set_property(DualMono, {Zone.ALL: "ATJ"}),
-    gen_set_property(FixedPcm, {Zone.ALL: "ATK"}),
+    gen_set_property(FixedPCM, {Zone.ALL: "ATK"}),
     gen_set_property(DynamicRange, {Zone.ALL: "ATL"}),
-    gen_set_property(LfeAttenuator, {Zone.ALL: "ATM"}),
-    gen_set_property(SacdGain, {Zone.ALL: "ATN"}),
+    gen_set_property(LFEAttenuator, {Zone.ALL: "ATM"}),
+    gen_set_property(SACDGain, {Zone.ALL: "ATN"}),
     gen_set_property(AutoDelay, {Zone.ALL: "ATO"}),
     gen_set_property(CenterWidth, {Zone.ALL: "ATP"}),
     gen_set_property(Panorama, {Zone.ALL: "ATQ"}),

--- a/aiopioneer/decoders/system.py
+++ b/aiopioneer/decoders/system.py
@@ -35,6 +35,8 @@ class SpeakerSystem(CodeDynamicDictStrMap):
     friendly_name = "speaker system"
     base_property = "system"
     property_name = "speaker_system"
+    supported_zones = (Zone.ALL,)
+    icon = "mdi:speaker-multiple"
 
     index_map_class = SpeakerSystemIndex
 
@@ -73,7 +75,7 @@ class SpeakerSystem(CodeDynamicDictStrMap):
         return [
             response,
             response.clone(
-                property_name="speaker_system_raw",
+                property_name="speaker_system_id",
                 value=SpeakerSystemIndex.code_to_value(response.code),
             ),
         ]
@@ -315,11 +317,16 @@ class XOver(CodeDictStrMap):
 
 
 class XCurve(CodeFloatMap):
-    """X curve (1step=0.5)"""
+    """X curve (1step = 0.5)"""
 
     friendly_name = "X curve"
     base_property = "system"
     property_name = "x_curve"
+    supported_zones = (Zone.ALL,)
+    icon = "mdi:tune-vertical"
+    unit_of_measurement = "dB"
+    ha_device_class = "signal_strength"
+    ha_number_mode = "box"
 
     code_zfill = 2
     value_min = -49.5
@@ -457,6 +464,11 @@ class InputLevel(CodeFloatMap):
     friendly_name = "input level"
     base_property = "system"
     property_name = "input_level"  # unused
+    supported_zones = (Zone.ALL,)
+    icon = "mdi:tune-vertical"
+    unit_of_measurement = "dB"
+    ha_device_class = "signal_strength"
+    ha_number_mode = "slider"
 
     code_zfill = 2
     code_offset = -50

--- a/aiopioneer/decoders/system.py
+++ b/aiopioneer/decoders/system.py
@@ -328,8 +328,8 @@ class XCurve(CodeFloatMap):
     ha_device_class = "signal_strength"
     ha_number_mode = "box"
 
-    code_zfill = 2
-    value_min = -49.5
+    code_zfill = 1
+    value_min = -3.0
     value_max = 0
     value_step = 0.5
     value_divider = -0.5

--- a/aiopioneer/decoders/tuner.py
+++ b/aiopioneer/decoders/tuner.py
@@ -19,7 +19,7 @@ from .response import Response
 
 
 class FrequencyFM(CodeFloatMap):
-    """Tuner FM frequency. (1step = 0.01MHz)"""
+    """Tuner FM frequency (1step = 0.01MHz)."""
 
     friendly_name = "FM frequency"
     base_property = "tuner"
@@ -47,7 +47,7 @@ class FrequencyFM(CodeFloatMap):
 
 
 class FrequencyAM(CodeIntMap):
-    """Tuner AM frequency. (1step = 1kHz)"""
+    """Tuner AM frequency (1step = 1kHz)."""
 
     friendly_name = "AM frequency"
     base_property = "tuner"
@@ -176,7 +176,7 @@ class Frequency(CodeMapSequence):
 
 
 class FrequencyAMStep(CodeIntMap):
-    """AM frequency step. (Supported on very few AVRs)"""
+    """AM frequency step (Supported on very few AVRs)."""
 
     friendly_name = "AM frequency step"
     base_property = "tuner"

--- a/aiopioneer/decoders/tuner.py
+++ b/aiopioneer/decoders/tuner.py
@@ -18,12 +18,13 @@ from .code_map import (
 from .response import Response
 
 
-class FrequencyFM(CodeFloatMap):
+class TunerFMFrequency(CodeFloatMap):
     """Tuner FM frequency (1step = 0.01MHz)."""
 
-    friendly_name = "FM frequency"
+    friendly_name = "tuner FM frequency"
     base_property = "tuner"
     property_name = "frequency"
+    unit_of_measurement = "MHz"
 
     value_min = 87.5
     value_max = 108.0
@@ -41,20 +42,21 @@ class FrequencyFM(CodeFloatMap):
         super().decode_response(response=response, params=params)
         return [
             response.clone(property_name="band", value=TunerBand.FM),
-            *Preset.update_preset(response),
+            *TunerPreset.update_preset(response),
             response,
         ]
 
 
-class FrequencyAM(CodeIntMap):
+class TunerAMFrequency(CodeIntMap):
     """Tuner AM frequency (1step = 1kHz)."""
 
-    friendly_name = "AM frequency"
+    friendly_name = "tuner AM frequency"
     base_property = "tuner"
     property_name = "frequency"
+    unit_of_measurement = "kHz"
     code_zfill = 5
 
-    value_bounds = {9: (531, 1701), 10: (530, 1700)}
+    value_bounds = {9: (531, 1701), 10: (530, 1700), None: (530, 1701)}
 
     @classmethod
     def get_frequency_bounds(cls, am_frequency_step: int) -> tuple[int, int]:
@@ -114,7 +116,7 @@ class FrequencyAM(CodeIntMap):
             elif not freq_div9 and freq_div10:
                 frequency_step = 10
             if frequency_step:
-                return FrequencyAMStep.update_frequency_step(
+                return TunerAMFrequencyStep.update_frequency_step(
                     response=response.clone(), frequency_step=frequency_step
                 )
 
@@ -133,12 +135,12 @@ class FrequencyAM(CodeIntMap):
         return [
             response.clone(inherit_property=False, callback=glean_frequency_step),
             response.clone(property_name="band", value=TunerBand.AM),
-            *Preset.update_preset(response),
+            *TunerPreset.update_preset(response),
             response,
         ]
 
 
-class FrequencyBand(CodeDictMap):
+class TunerFrequencyBand(CodeDictMap):
     """Tuner frequency band."""
 
     friendly_name = "tuner frequency band"
@@ -148,18 +150,18 @@ class FrequencyBand(CodeDictMap):
     code_map = {"A": TunerBand.AM, "F": TunerBand.FM}
 
 
-class Frequency(CodeMapSequence):
+class TunerFrequency(CodeMapSequence):
     """Tuner frequency."""
 
-    friendly_name = "frequency"
+    friendly_name = "tuner frequency"
     base_property = "tuner"
     property_name = "frequency"
 
-    code_map_sequence = [FrequencyBand, FrequencyFM]  ## NOTE: placeholder
+    code_map_sequence = [TunerFrequencyBand, TunerFMFrequency]  ## NOTE: placeholder
 
     BAND_MAP: dict[TunerBand, type[CodeMapBase]] = {
-        TunerBand.AM: FrequencyAM,
-        TunerBand.FM: FrequencyFM,
+        TunerBand.AM: TunerAMFrequency,
+        TunerBand.FM: TunerFMFrequency,
     }
 
     @classmethod
@@ -171,14 +173,14 @@ class Frequency(CodeMapSequence):
         """Response decoder for tuner frequency."""
         band_code = response.code[0]
         response.update(code=response.code[1:])
-        band = FrequencyBand.code_to_value(code=band_code)
+        band = TunerFrequencyBand.code_to_value(code=band_code)
         return cls.BAND_MAP[band].decode_response(response, params=params)
 
 
-class FrequencyAMStep(CodeIntMap):
+class TunerAMFrequencyStep(CodeIntMap):
     """AM frequency step (Supported on very few AVRs)."""
 
-    friendly_name = "AM frequency step"
+    friendly_name = "tuner AM frequency step"
     base_property = "tuner"
     property_name = "am_frequency_step"
 
@@ -208,12 +210,16 @@ class FrequencyAMStep(CodeIntMap):
         return [response]
 
 
-class Preset(CodeStrMap):
+class TunerPreset(CodeStrMap):
     """Tuner preset."""
 
     friendly_name = "tuner preset"
     base_property = "tuner"
     property_name = "preset"
+    supported_zones = (Zone.ALL,)
+    icon = "mdi:radio"
+    ha_auto_entity = False
+    ha_enable_default = True
 
     @classmethod
     def decode_response(
@@ -284,16 +290,14 @@ class Preset(CodeStrMap):
 
 
 PROPERTIES_TUNER = [
-    gen_query_property(Frequency, {Zone.ALL: "FR"}),
+    gen_query_property(TunerFrequency, {Zone.ALL: "FR"}),
     gen_set_property(
-        Preset,
+        TunerPreset,
         {Zone.ALL: "PR"},
         set_command="select_tuner_preset",
         retry_set_on_fail=True,
     ),
-    gen_query_property(
-        FrequencyAMStep, {Zone.ALL: "SUQ"}, query_command="query_tuner_am_step"
-    ),
+    gen_query_property(TunerAMFrequencyStep, {Zone.ALL: "SUQ"}),
 ]
 
 EXTRA_COMMANDS_TUNER = [

--- a/aiopioneer/decoders/video.py
+++ b/aiopioneer/decoders/video.py
@@ -80,7 +80,7 @@ class VideoSignalOutputResolution(VideoSignalFormat):
     property_name = "signal_output_resolution"
 
 
-class VideoSignalHdmi1RecommendedResolution(VideoSignalFormat):
+class VideoSignalHDMI1RecommendedResolution(VideoSignalFormat):
     """Video signal HDMI1 recommended resolution."""
 
     friendly_name = "video signal HDMI1 recommended resolution"
@@ -88,7 +88,7 @@ class VideoSignalHdmi1RecommendedResolution(VideoSignalFormat):
     property_name = "signal_hdmi1_recommended_resolution"
 
 
-class VideoSignalHdmi2RecommendedResolution(VideoSignalFormat):
+class VideoSignalHDMI2RecommendedResolution(VideoSignalFormat):
     """Video signal HDMI2 recommended resolution."""
 
     friendly_name = "video signal HDMI2 recommended resolution"
@@ -96,7 +96,7 @@ class VideoSignalHdmi2RecommendedResolution(VideoSignalFormat):
     property_name = "signal_hdmi2_recommended_resolution"
 
 
-class VideoSignalHdmi3RecommendedResolution(VideoSignalFormat):
+class VideoSignalHDMI3RecommendedResolution(VideoSignalFormat):
     """Video signal HDMI3 recommended resolution."""
 
     friendly_name = "video signal HDMI3 recommended resolution"
@@ -104,7 +104,7 @@ class VideoSignalHdmi3RecommendedResolution(VideoSignalFormat):
     property_name = "signal_hdmi3_recommended_resolution"
 
 
-class VideoSignalHdmi4RecommendedResolution(VideoSignalFormat):
+class VideoSignalHDMI4RecommendedResolution(VideoSignalFormat):
     """Video signal HDMI4 recommended resolution."""
 
     friendly_name = "video signal HDMI4 recommended resolution"
@@ -211,7 +211,7 @@ class VideoSignalOutputBits(VideoSignalBits):
     property_name = "signal_output_bit"  # NOTE: inconsistent
 
 
-class VideoSignalHdmi1Deepcolor(VideoSignalBits):
+class VideoSignalHDMI1Deepcolor(VideoSignalBits):
     """Video signal HDMI1 deepcolor."""
 
     friendly_name = "video signal HDMI1 deepcolor"
@@ -219,7 +219,7 @@ class VideoSignalHdmi1Deepcolor(VideoSignalBits):
     property_name = "signal_hdmi1_deepcolor"  # NOTE: inconsistent
 
 
-class VideoSignalHdmi2Deepcolor(VideoSignalBits):
+class VideoSignalHDMI2Deepcolor(VideoSignalBits):
     """Video signal HDMI2 deepcolor."""
 
     friendly_name = "video signal HDMI2 deepcolor"
@@ -227,7 +227,7 @@ class VideoSignalHdmi2Deepcolor(VideoSignalBits):
     property_name = "signal_hdmi2_deepcolor"  # NOTE: inconsistent
 
 
-class VideoSignalHdmi3Deepcolor(VideoSignalBits):
+class VideoSignalHDMI3Deepcolor(VideoSignalBits):
     """Video signal HDMI3 deepcolor."""
 
     friendly_name = "video signal HDMI3 deepcolor"
@@ -235,7 +235,7 @@ class VideoSignalHdmi3Deepcolor(VideoSignalBits):
     property_name = "signal_hdmi3_deepcolor"  # NOTE: inconsistent
 
 
-class VideoSignalHdmi4Deepcolor(VideoSignalBits):
+class VideoSignalHDMI4Deepcolor(VideoSignalBits):
     """Video signal HDMI4 deepcolor."""
 
     friendly_name = "video signal HDMI4 deepcolor"
@@ -334,23 +334,23 @@ class VideoInformation(CodeMapSequence):
         VideoSignalOutputColorspace,  # [10] signal_output_color_format
         VideoSignalOutputBits,  # [11] signal_output_bit
         VideoSignalOutputExtendedColorspace,  # [12] signal_output_extended_colorspace
-        VideoSignalHdmi1RecommendedResolution,  # [13:15] signal_hdmi1_recommended_resolution
-        VideoSignalHdmi1Deepcolor,  # [15] signal_hdmi1_deepcolor
+        VideoSignalHDMI1RecommendedResolution,  # [13:15] signal_hdmi1_recommended_resolution
+        VideoSignalHDMI1Deepcolor,  # [15] signal_hdmi1_deepcolor
         CodeMapBlank(5),
-        VideoSignalHdmi2RecommendedResolution,  # [21:23] signal_hdmi2_recommended_resolution
-        VideoSignalHdmi2Deepcolor,  # [23] signal_hdmi2_deepcolor
+        VideoSignalHDMI2RecommendedResolution,  # [21:23] signal_hdmi2_recommended_resolution
+        VideoSignalHDMI2Deepcolor,  # [23] signal_hdmi2_deepcolor
     ]
 
     code_map_sequence_extra = [
         *code_map_sequence,
         CodeMapBlank(5),
-        VideoSignalHdmi3RecommendedResolution,  # [29:31] signal_hdmi3_recommended_resolution
-        VideoSignalHdmi3Deepcolor,  # [31] signal_hdmi3_deepcolor
+        VideoSignalHDMI3RecommendedResolution,  # [29:31] signal_hdmi3_recommended_resolution
+        VideoSignalHDMI3Deepcolor,  # [31] signal_hdmi3_deepcolor
         CodeMapBlank(5),
         VideoSignalInput3DFormat,  # [37:39] input_3d_format
         VideoSignalOutput3DFormat,  # [39:41] output_3d_format
-        VideoSignalHdmi4RecommendedResolution,  # [41:43] signal_hdmi4_recommended_resolution
-        VideoSignalHdmi4Deepcolor,  # [44] signal_hdmi4_deepcolor
+        VideoSignalHDMI4RecommendedResolution,  # [41:43] signal_hdmi4_recommended_resolution
+        VideoSignalHDMI4Deepcolor,  # [44] signal_hdmi4_deepcolor
     ]
 
     @classmethod
@@ -377,17 +377,19 @@ class VideoResolution(CodeDictStrMap):
     friendly_name = "video resolution"
     base_property = "video"
     property_name = "resolution"
+    supported_zones = (Zone.Z1,)
+    icon = "mdi:monitor-screenshot"
 
     code_map = {
-        "0": "auto",
-        "1": "pure",
-        "3": "480/576p",
-        "4": "720p",
-        "5": "1080i",
-        "6": "1080p",
-        "7": "1080/24p",
-        "8": "4K",
-        "9": "4K/24p",
+        "00": "auto",
+        "01": "pure",
+        "03": "480/576p",
+        "04": "720p",
+        "05": "1080i",
+        "06": "1080p",
+        "07": "1080/24p",
+        "08": "4K",
+        "09": "4K/24p",
     }
 
     @classmethod
@@ -429,11 +431,14 @@ class VideoPureCinema(CodeDictStrMap):
 
 
 class VideoProgMotion(CodeIntMap):
-    """Video prog motion."""
+    """Video progressive motion."""
 
-    friendly_name = "video prog motion"
+    friendly_name = "video progressive motion"
     base_property = "video"
     property_name = "prog_motion"
+    supported_zones = (Zone.ALL,)
+    icon = "mdi:monitor-shimmer"
+    ha_number_mode = "slider"
 
     value_min = -4
     value_max = 4
@@ -447,6 +452,8 @@ class VideoStreamSmoother(CodeDictStrMap):
     friendly_name = "video stream smoother"
     base_property = "video"
     property_name = "stream_smoother"
+    supported_zones = (Zone.Z1,)
+    icon = "mdi:monitor-shimmer"
 
     code_map = {"0": "off", "1": "on", "2": "auto"}
 
@@ -457,6 +464,8 @@ class AdvancedVideoAdjust(CodeDictStrMap):
     friendly_name = "advanced video adjust"
     base_property = "video"
     property_name = "advanced_video_adjust"
+    supported_zones = (Zone.Z1,)
+    icon = "mdi:monitor-shimmer"
 
     code_map = {"0": "PDP", "1": "LCD", "2": "FPJ", "3": "professional", "4": "memory"}
 
@@ -485,36 +494,48 @@ class VideoInt66Map(CodeIntMap):
     code_zfill = 2
 
 
-class VideoYnr(VideoInt08Map):
-    """Video YNR."""
+class VideoYNR(VideoInt08Map):
+    """Video YNR (brightness noise reduction)."""
 
     friendly_name = "video YNR"
     base_property = "video"
     property_name = "ynr"
+    supported_zones = (Zone.Z1,)
+    icon = "mdi:monitor-shimmer"
+    ha_number_mode = "slider"
 
 
-class VideoCnr(VideoInt08Map):
-    """Video CNR."""
+class VideoCNR(VideoInt08Map):
+    """Video CNR (colour noise reduction)."""
 
     friendly_name = "video CNR"
     base_property = "video"
     property_name = "cnr"
+    supported_zones = (Zone.Z1,)
+    icon = "mdi:monitor-shimmer"
+    ha_number_mode = "slider"
 
 
-class VideoBnr(VideoInt08Map):
-    """Video BNR."""
+class VideoBNR(VideoInt08Map):
+    """Video BNR (block noise reduction)."""
 
     friendly_name = "video BNR"
     base_property = "video"
     property_name = "bnr"
+    supported_zones = (Zone.Z1,)
+    icon = "mdi:monitor-shimmer"
+    ha_number_mode = "slider"
 
 
-class VideoMnr(VideoInt08Map):
-    """Video MNR."""
+class VideoMNR(VideoInt08Map):
+    """Video MNR (mosquito noise reduction)."""
 
     friendly_name = "video MNR"
     base_property = "video"
     property_name = "mnr"
+    supported_zones = (Zone.Z1,)
+    icon = "mdi:monitor-shimmer"
+    ha_number_mode = "slider"
 
 
 class VideoDetail(VideoInt08Map):
@@ -523,6 +544,9 @@ class VideoDetail(VideoInt08Map):
     friendly_name = "video detail"
     base_property = "video"
     property_name = "detail"
+    supported_zones = (Zone.Z1,)
+    icon = "mdi:monitor-shimmer"
+    ha_number_mode = "slider"
 
 
 class VideoSharpness(VideoInt08Map):
@@ -531,6 +555,9 @@ class VideoSharpness(VideoInt08Map):
     friendly_name = "video sharpness"
     base_property = "video"
     property_name = "sharpness"
+    supported_zones = (Zone.Z1,)
+    icon = "mdi:monitor-shimmer"
+    ha_number_mode = "slider"
 
 
 class VideoBrightness(VideoInt66Map):
@@ -539,6 +566,9 @@ class VideoBrightness(VideoInt66Map):
     friendly_name = "video brightness"
     base_property = "video"
     property_name = "brightness"
+    supported_zones = (Zone.Z1,)
+    icon = "mdi:monitor-shimmer"
+    ha_number_mode = "slider"
 
 
 class VideoContrast(VideoInt66Map):
@@ -547,6 +577,9 @@ class VideoContrast(VideoInt66Map):
     friendly_name = "video contrast"
     base_property = "video"
     property_name = "contrast"
+    supported_zones = (Zone.Z1,)
+    icon = "mdi:monitor-shimmer"
+    ha_number_mode = "slider"
 
 
 class VideoHue(VideoInt66Map):
@@ -555,6 +588,9 @@ class VideoHue(VideoInt66Map):
     friendly_name = "video hue"
     base_property = "video"
     property_name = "hue"
+    supported_zones = (Zone.Z1,)
+    icon = "mdi:monitor-shimmer"
+    ha_number_mode = "slider"
 
 
 class VideoChroma(VideoInt66Map):
@@ -563,6 +599,9 @@ class VideoChroma(VideoInt66Map):
     friendly_name = "video chroma"
     base_property = "video"
     property_name = "chroma"
+    supported_zones = (Zone.Z1,)
+    icon = "mdi:monitor-shimmer"
+    ha_number_mode = "slider"
 
 
 class VideoBlackSetup(CodeBoolMap):
@@ -579,6 +618,8 @@ class VideoAspect(CodeDictStrMap):
     friendly_name = "video aspect"
     base_property = "video"
     property_name = "aspect"
+    supported_zones = (Zone.Z1,)
+    icon = "mdi:monitor-screenshot"
 
     code_map = {"0": "passthrough", "1": "normal"}
 
@@ -589,6 +630,9 @@ class VideoSuperResolution(CodeIntMap):
     friendly_name = "video super resolution"
     base_property = "video"
     property_name = "super_resolution"
+    supported_zones = (Zone.Z1,)
+    icon = "mdi:monitor-shimmer"
+    ha_number_mode = "slider"
 
     value_min = 0
     value_max = 3
@@ -603,10 +647,10 @@ PROPERTIES_VIDEO = [
     gen_set_property(VideoProgMotion, {Zone.Z1: "VTE"}),
     gen_set_property(VideoStreamSmoother, {Zone.Z1: "VTF"}),
     gen_set_property(AdvancedVideoAdjust, {Zone.Z1: "VTG"}),
-    gen_set_property(VideoYnr, {Zone.Z1: "VTH"}),
-    gen_set_property(VideoCnr, {Zone.Z1: "VTI"}),
-    gen_set_property(VideoBnr, {Zone.Z1: "VTJ"}),
-    gen_set_property(VideoMnr, {Zone.Z1: "VTK"}),
+    gen_set_property(VideoYNR, {Zone.Z1: "VTH"}),
+    gen_set_property(VideoCNR, {Zone.Z1: "VTI"}),
+    gen_set_property(VideoBNR, {Zone.Z1: "VTJ"}),
+    gen_set_property(VideoMNR, {Zone.Z1: "VTK"}),
     gen_set_property(VideoDetail, {Zone.Z1: "VTL"}),
     gen_set_property(VideoSharpness, {Zone.Z1: "VTM"}),
     gen_set_property(VideoBrightness, {Zone.Z1: "VTN"}),

--- a/aiopioneer/pioneer_avr.py
+++ b/aiopioneer/pioneer_avr.py
@@ -24,7 +24,7 @@ from .const import (
 )
 from .decode import process_raw_response
 from .decoders.amp import Volume
-from .decoders.tuner import FrequencyAM, FrequencyFM
+from .decoders.tuner import TunerAMFrequency, TunerFMFrequency
 from .exceptions import (
     AVRError,
     AVRResponseTimeoutError,
@@ -711,8 +711,8 @@ class PioneerAVR(AVRConnection):
         if self.properties.tuner.get("am_frequency_step"):
             return
 
-        ## Try sending the query_tuner_am_step command first
-        if await self.send_command("query_tuner_am_step", ignore_error=True):
+        ## Try sending the query_tuner_am_frequency_step command first
+        if await self.send_command("query_tuner_am_frequency_step", ignore_error=True):
             return
 
         ## Step frequency once and check whether difference was calculated
@@ -784,9 +784,9 @@ class PioneerAVR(AVRConnection):
             await self.properties.command_queue.wait()  ## for AM step calculation
 
         if band is TunerBand.AM:
-            code = FrequencyAM.value_to_code(frequency, properties=self.properties)
+            code = TunerAMFrequency.value_to_code(frequency, properties=self.properties)
         else:
-            code = FrequencyFM.value_to_code(frequency)
+            code = TunerFMFrequency.value_to_code(frequency)
 
         if await self.send_command("tuner_direct_access", ignore_error=True):
             ## Set tuner frequency directly if command is supported

--- a/aiopioneer/property_registry.py
+++ b/aiopioneer/property_registry.py
@@ -68,6 +68,22 @@ class AVRPropertyRegistry:
             and (zone is None or zone in c.avr_commands)
         )
 
+    def get_code_maps(
+        self,
+        base_class: type[CodeMapBase],
+        zone: Zone = None,
+        is_ha_auto_entity: bool = False,
+    ) -> list[type[CodeMapBase]]:
+        """Return property entries matching a CodeMapBase subclass."""
+        classes: list[type[CodeMapBase]] = []
+        for code_map in self.code_map_index:
+            if issubclass(code_map, base_class):
+                if (zone is None or zone in code_map.supported_zones) and (
+                    not is_ha_auto_entity or code_map.ha_auto_entity
+                ):
+                    classes.append(code_map)
+        return classes
+
     def match_response(self, raw_resp: str) -> tuple[str, type[CodeMapBase], Zone]:
         """Return code map for response."""
         return next((r for r in self.responses if raw_resp.startswith(r[0])), None)
@@ -225,3 +241,17 @@ PROPERTY_REGISTRY = AVRPropertyRegistry(
     + EXTRA_COMMANDS_BLUETOOTH
     + EXTRA_COMMANDS_MHL,
 )
+
+
+def get_property_entry(code_map: type[CodeMapBase]) -> AVRPropertyEntry:
+    """Return property entry for code map."""
+    return PROPERTY_REGISTRY.code_map_index[code_map]
+
+
+def get_code_maps(
+    base_class: type[CodeMapBase], zone: Zone = None, is_ha_auto_entity: bool = False
+) -> list[type[CodeMapBase]]:
+    """Convenience function to return property entries matching a CodeMapBase subclass."""
+    return PROPERTY_REGISTRY.get_code_maps(
+        base_class=base_class, zone=zone, is_ha_auto_entity=is_ha_auto_entity
+    )


### PR DESCRIPTION
## What's Changed
* Properties have been added to code maps to support auto generating select, number and switch entities in HA for AVR properties
* The system X curve code map has been corrected to match the mapping defined in the FY16 doc
* The video resolution code map has been corrected to use a 2 char code map as defined in the FY16 doc

## Breaking Changes
* System property `speaker_system_raw` has been renamed to `speaker_system_id` for consistency
* AVR command `query_tuner_am_step` has been renamed to `query_tuner_am_frequency_step` to match the property and code map class name
