### PR TITLE
Re-enable video queries on VSX-930

### DIFF
--- a/aiopioneer/params.py
+++ b/aiopioneer/params.py
@@ -319,7 +319,6 @@ PARAM_MODEL_DEFAULTS = OrderedDict(
                     151,
                     212,
                 ],
-                PARAM_ENABLED_FUNCTIONS: DEFAULT_ENABLED_FUNCTIONS_NO_VIDEO,
             },
         ),
         (


### PR DESCRIPTION
## What's Changed
* The `video` function has been re-enabled again on the VSX-930