### PR TITLE
Rename channel_levels property, PioneerAVR method and AVR commands to channel_level

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,7 +107,7 @@ Listed below are the public attributes of a `AVRProperties` object that contains
 | `video` | **dict**[**str** \| Zone, **str**] | Current AVR video parameters
 | `audio` | **dict**[**str** \| Zone, **str**] | Current AVR audio parameters
 | `system` | **dict**[**str** \| Zone, **str**]| AVR system attributes
-| `channel_levels` | **dict**[**str**, **Any**] | Current AVR channel levels, indexed by channel name
+| `channel_level` | **dict**[**str**, dict[Zone, **Any**]] | Current AVR channel level, indexed by zone and channel name
 | `ip_control_port_n` | **str** | IP control ports configured on the AVR (where `n` is the port index)
 
 ## Command line interface (CLI)
@@ -137,7 +137,7 @@ The CLI accepts all AVR commands, as well as the helper commands below. The `lis
 | `get_params` | | Show the currently active set of parameters
 | `get_user_params` | | Show the currently active set of user parameters
 | `set_user_params` | _params_ (JSON) | Set the user parameters to _params_ (see [CLI JSON arguments](#cli-json-arguments) below)
-| `get_properties` | \[ `--zones` \]<br>\[ `--power` \]<br>\[ `--volume` \]<br>\[ `--max_volume` \]<br>\[ `--mute` \]<br>\[ `--source_id` \]<br>\[ `--source_name` \]<br>\[ `--media_control_mode` \]<br>\[ `--tone` \]<br>\[ `--amp` \]<br>\[ `--tuner` \]<br>\[ `--dsp` \]<br>\[ `--video` \]<br>\[ `--system` \]<br>\[ `--audio` \]<br>\[ `--channel_levels` \] | Show the current cached AVR properties for the specified property groups, or all property groups if none are specified
+| `get_properties` | \[ `--zones` \]<br>\[ `--power` \]<br>\[ `--volume` \]<br>\[ `--max_volume` \]<br>\[ `--mute` \]<br>\[ `--source_id` \]<br>\[ `--source_name` \]<br>\[ `--media_control_mode` \]<br>\[ `--tone` \]<br>\[ `--amp` \]<br>\[ `--tuner` \]<br>\[ `--dsp` \]<br>\[ `--video` \]<br>\[ `--system` \]<br>\[ `--audio` \]<br>\[ `--channel_level` \] | Show the current cached AVR properties for the specified property groups, or all property groups if none are specified
 | `get_scan_interval` | | Show the current scan interval.
 | `set_scan_interval` | _scan_interval_ (float) | Set the scan interval to _scan_interval_
 | `refresh` | [`--full`] | Refresh the cached AVR properties for the active zone, or all zones if `--full` is specified

--- a/aiopioneer/cli.py
+++ b/aiopioneer/cli.py
@@ -54,7 +54,7 @@ PROPS_ALL = [
     "video",
     "system",
     "audio",
-    "channel_levels",
+    "channel_level",
 ]
 
 

--- a/aiopioneer/decoders/audio.py
+++ b/aiopioneer/decoders/audio.py
@@ -296,7 +296,7 @@ class ChannelLevel(CodeFloatMap):
     """Channel level (1step = 0.5dB)."""
 
     friendly_name = "channel level"
-    base_property = "channel_levels"
+    base_property = "channel_level"
 
     value_min = -12
     value_max = 12
@@ -343,9 +343,9 @@ class SpeakerChannel(CodeStrMap):
     ) -> str:
         channel: str = args[0]
         if channel != "all" and zone in properties.zones_initial_refresh:
-            if (channel_levels := properties.channel_levels.get(zone)) is None:
+            if (channel_levels := properties.channel_level.get(zone)) is None:
                 raise AVRCommandUnavailableError(
-                    command=command, err_key="channel_levels", zone=zone
+                    command=command, err_key="channel_level", zone=zone
                 )
             if channel_levels.get(channel) is None:
                 raise AVRCommandUnavailableError(
@@ -360,7 +360,7 @@ class SpeakerChannelLevel(CodeMapSequence):
     """Speaker channel level."""
 
     friendly_name = "speaker channel level"
-    base_property = "channel_levels"
+    base_property = "channel_level"
     code_map_sequence = [SpeakerChannel, ChannelLevel]
 
     @classmethod
@@ -371,7 +371,7 @@ class SpeakerChannelLevel(CodeMapSequence):
         level_code = responses[1].code
         if speaker == "ALL":
             responses = []
-            channel_levels = response.properties.channel_levels.get(response.zone, {})
+            channel_levels = response.properties.channel_level.get(response.zone, {})
             for channel in channel_levels.keys():
                 responses.append(
                     response.clone(code=level_code, property_name=channel, value=level)

--- a/aiopioneer/exceptions.py
+++ b/aiopioneer/exceptions.py
@@ -203,7 +203,7 @@ CommandResponseErrorFormatText = {
 CommandUnavailableErrorFormatText = {
     "tuner": "AVR tuner is unavailable",
     "tone": "tone controls not supported for {zone.full_name}",
-    "channel_levels": "channel levels not supported for {zone.full_name}",
+    "channel_level": "channel levels not supported for {zone.full_name}",
     "channel": "channel {channel} unavailable for {zone.full_name}",
     "video_settings": "video settings not supported for {zone.full_name}",
     "dsp_settings": "DSP settings not supported for {zone.full_name}",

--- a/aiopioneer/pioneer_avr.py
+++ b/aiopioneer/pioneer_avr.py
@@ -347,10 +347,10 @@ class PioneerAVR(AVRConnection):
                 for command in PROPERTY_REGISTRY.get_commands(
                     prefix=f"query_{func}", zone=zone
                 ):
-                    if command.name == "query_channel_levels":
+                    if command.name == "query_channel_level":
                         channels = CHANNELS_ALL
                         if zone in self.properties.zones_initial_refresh:
-                            channels = self.properties.channel_levels.get(
+                            channels = self.properties.channel_level.get(
                                 zone, {}
                             ).keys()
                         for channel in channels:
@@ -826,12 +826,12 @@ class PioneerAVR(AVRConnection):
         """Select the next tuner preset."""
         await self.send_command("tuner_next_preset")
 
-    async def set_channel_levels(
+    async def set_channel_level(
         self, channel: str, level: float, zone: Zone = Zone.Z1
     ) -> None:
         """Set the level (gain) for amplifier channel in zone."""
         zone = self._check_zone(zone)
-        await self.send_command("set_channel_levels", channel, level, zone=zone)
+        await self.send_command("set_channel_level", channel, level, zone=zone)
 
     async def set_video_settings(self, zone: Zone, **arguments) -> None:
         """Set video settings for a given zone."""

--- a/aiopioneer/properties.py
+++ b/aiopioneer/properties.py
@@ -56,7 +56,7 @@ class AVRProperties:
         self.audio: dict[str | Zone, Any] = {}
 
         ## Complex object that holds multiple different props for the CHANNEL/DSP functions
-        self.channel_levels: dict[Zone, dict[str, Any]] = {}
+        self.channel_level: dict[Zone, dict[str, Any]] = {}
 
         ## Source name mappings
         self.query_sources = None

--- a/python_api.md
+++ b/python_api.md
@@ -253,7 +253,7 @@ Set the tone settings for zone _zone_ to _tone_. When _tone_ is set to `On`, _tr
 
 Return a list of all valid media control actions for a given zone. If the provided zone source is not currently compatible with media controls, **None** will be returned.
 
-_awaitable_ `PioneerAVR.set_channel_levels(`_channel_: **str**, _level_: **float**, _zone_: Zone = Zone.Z1`)` -> **bool**
+_awaitable_ `PioneerAVR.set_channel_level(`_channel_: **str**, _level_: **float**, _zone_: Zone = Zone.Z1`)` -> **bool**
 
 Set the level (gain) for amplifier channel in zone _zone_.
 


### PR DESCRIPTION
## Breaking Changes
* Property `channel_levels` has been renamed to `channel_level`
* PioneerAVR method `set_channel_levels` has been renamed to `set_channel_level`
* AVR commands `set/query_channel_levels` have been renamed to `set/query_channel_level`
