### PR TITLE
Harmonise code map HDMI values

### DIFF
--- a/README.md
+++ b/README.md
@@ -177,13 +177,13 @@ The list below shows the source ID that corresponds to each AVR source:
 | 06 | SAT/CBL
 | 10 | VIDEO
 | 15 | DVR/BDR
-| 19 | HDMI 1
-| 20 | HDMI 2
-| 21 | HDMI 3
-| 22 | HDMI 4
-| 23 | HDMI 5
-| 24 | HDMI 6
-| 34 | HDMI 7
+| 19 | HDMI1
+| 20 | HDMI2
+| 21 | HDMI3
+| 22 | HDMI4
+| 23 | HDMI5
+| 24 | HDMI6
+| 34 | HDMI7
 | 49 | GAME
 | 26 | NETWORK (cyclic)
 | 38 | INTERNET RADIO

--- a/aiopioneer/decoders/amp.py
+++ b/aiopioneer/decoders/amp.py
@@ -336,7 +336,7 @@ class HDMIOut(CodeMapHasPropertyMixin, CodeDictStrMap):
     supported_zones = {Zone.ALL}
     icon = "mdi:monitor-share"
 
-    code_map = {"0": "all", "1": "HDMI 1", "2": "HDMI 2"}
+    code_map = {"0": "all", "1": "HDMI1", "2": "HDMI2"}
 
 
 class HDMI3Out(CodeMapHasPropertyMixin, CodeBoolMap):

--- a/aiopioneer/decoders/system.py
+++ b/aiopioneer/decoders/system.py
@@ -677,10 +677,10 @@ class ExternalHdmiTrigger(CodeDictStrMap):
 
     code_map = {
         "0": "off",
-        "1": "HDMI OUT 1",
-        "2": "HDMI OUT 2",
-        "3": "HDMI OUT 3",
-        "4": "HDMI OUT 4/HDBaseT",
+        "1": "HDMI1 out",
+        "2": "HDMI2 out",
+        "3": "HDMI3 out",
+        "4": "HDMI4 out/HDBaseT",
     }
 
     @classmethod


### PR DESCRIPTION
## Breaking Changes
* The values for the `amp.hdmi_out` and `system.external_hdmi_trigger_[12]` properties have been revised to harmonise HDMI port names