### PR TITLE
Remove get_source_list

### DIFF
--- a/aiopioneer/properties.py
+++ b/aiopioneer/properties.py
@@ -105,15 +105,6 @@ class AVRProperties:
         except (ValueError, KeyError) as exc:
             raise AVRLocalCommandError(command="set_source_dict", exc=exc) from exc
 
-    def get_source_list(self, zone: Zone = Zone.Z1) -> list[str]:
-        """Return list of available input sources for zone."""
-        source_ids: list[int] = None
-        if zone is not None:
-            source_ids = self._params.get_param(PARAM_ZONE_SOURCES[zone], [])
-        if not source_ids:
-            return list(self.source_id_to_name.values())
-        return list(v for k, v in self.source_id_to_name.items() if k in source_ids)
-
     def get_source_dict(self, zone: Zone = None) -> dict[int, str]:
         """Return source ID to name mapping for zone."""
         source_ids: list[int] = None

--- a/python_api.md
+++ b/python_api.md
@@ -94,10 +94,6 @@ Parameter `max_source_id` determines the highest source ID that is queried.
 
 Manually set the available sources to the dict _sources_, where the keys are integer source IDs and the values are the corresponding source names.
 
-`AVRProperties.get_source_list(`_zone_: Zone = Zone.Z1`)` -> **list**[**str**]
-
-Return the set of currently available source names for _zone_. The source names can be used with the `select_source` method.
-
 `AVRProperties.get_source_dict(`_zone_: Zone = **None**`)` -> **dict**[**int**, **str**]
 
 Return a dict of currently available source ID to source name mappings for _zone_. <br/>


### PR DESCRIPTION
## Breaking Changes
* `PioneerAVR.properties.get_source_list` method has been removed. Use `PioneerAVR.properties.get_source_dict().values()` to retrieve the list of valid sources for a zone