### PR TITLE
Breaking: Use serialx for connection handling

### DIFF
--- a/aiopioneer/connection.py
+++ b/aiopioneer/connection.py
@@ -41,28 +41,18 @@ class AVRConnection:
     def __init__(  # pylint: disable=super-init-not-called
         self,
         params: AVRParams,
-        url: str | None = None,
-        host: str | None = None,
-        port: int | None = None,
+        url: str,
         timeout: float = DEFAULT_TIMEOUT,
         scan_interval: float = DEFAULT_SCAN_INTERVAL,
     ):
         """Initialise the Pioneer AVR connection."""
         _LOGGER.debug(
-            ">> AVRConnection.__init__(url=%s, host=%s, port=%s, timeout=%s, scan_interval=%s)",
+            ">> AVRConnection.__init__(url=%s, timeout=%s, scan_interval=%s)",
             repr(url),
-            repr(host),
-            repr(port),
             repr(timeout),
             repr(scan_interval),
         )
         self.params = params
-        if url is None and host is None and port is None:
-            raise ValueError("Either url or host and port must be provided")
-        if host is not None and port is None:
-            port = DEFAULT_PORT
-        if url is None:
-            url = f"socket://{host}:{port}"
         self._url = url
         self._timeout = timeout
         self.scan_interval = scan_interval
@@ -107,7 +97,7 @@ class AVRConnection:
                     stopbits=serialx.STOPBITS_ONE,
                     bytesize=serialx.EIGHTBITS,
                 )
-            except serialx.SerialTimeoutException as exc:
+            except (serialx.SerialTimeoutException, TimeoutError) as exc:
                 raise AVRConnectTimeoutError(exc=exc) from exc
             except Exception as exc:  # pylint: disable=broad-except
                 raise AVRConnectError(exc=exc) from exc

--- a/aiopioneer/connection.py
+++ b/aiopioneer/connection.py
@@ -6,6 +6,7 @@ import asyncio
 import logging
 import time
 import traceback
+import serialx
 
 from .const import DEFAULT_PORT, DEFAULT_TIMEOUT, DEFAULT_SCAN_INTERVAL
 from .exceptions import (
@@ -40,22 +41,29 @@ class AVRConnection:
     def __init__(  # pylint: disable=super-init-not-called
         self,
         params: AVRParams,
-        host: str,
-        port: int = DEFAULT_PORT,
+        url: str | None = None,
+        host: str | None = None,
+        port: int | None = None,
         timeout: float = DEFAULT_TIMEOUT,
         scan_interval: float = DEFAULT_SCAN_INTERVAL,
     ):
         """Initialise the Pioneer AVR connection."""
         _LOGGER.debug(
-            ">> AVRConnection.__init__(host=%s, port=%s, timeout=%s, scan_interval=%s)",
+            ">> AVRConnection.__init__(url=%s, host=%s, port=%s, timeout=%s, scan_interval=%s)",
+            repr(url),
             repr(host),
             repr(port),
             repr(timeout),
             repr(scan_interval),
         )
         self.params = params
-        self._host = host
-        self._port = port
+        if url is None and host is None and port is None:
+            raise ValueError("Either url or host and port must be provided")
+        if host is not None and port is None:
+            port = DEFAULT_PORT
+        if url is None:
+            url = f"socket://{host}:{port}"
+        self._url = url
         self._timeout = timeout
         self.scan_interval = scan_interval
 
@@ -91,13 +99,15 @@ class AVRConnection:
         async with self._connect_lock:
             _LOGGER.debug("opening AVR connection")
             try:
-                reader, writer = (
-                    await asyncio.wait_for(  # pylint: disable=unused-variable
-                        asyncio.open_connection(self._host, self._port),
-                        timeout=self._timeout,
-                    )
+                reader, writer = await serialx.open_serial_connection(
+                    url=self._url,
+                    timeout=self._timeout,
+                    baudrate=9600,
+                    parity=serialx.PARITY_NONE,
+                    stopbits=serialx.STOPBITS_ONE,
+                    bytesize=serialx.EIGHTBITS,
                 )
-            except TimeoutError as exc:
+            except serialx.SerialTimeoutException as exc:
                 raise AVRConnectTimeoutError(exc=exc) from exc
             except Exception as exc:  # pylint: disable=broad-except
                 raise AVRConnectError(exc=exc) from exc

--- a/aiopioneer/pioneer_avr.py
+++ b/aiopioneer/pioneer_avr.py
@@ -65,8 +65,7 @@ class PioneerAVR(AVRConnection):
 
     def __init__(
         self,
-        host: str,
-        port: int = DEFAULT_PORT,
+        url: str,
         timeout: float = DEFAULT_TIMEOUT,
         scan_interval: float = DEFAULT_SCAN_INTERVAL,
         params: dict[str, str] = None,
@@ -80,8 +79,7 @@ class PioneerAVR(AVRConnection):
         )
         super().__init__(
             params=self.params,
-            host=host,
-            port=port,
+            url=url,
             timeout=timeout,
             scan_interval=scan_interval,
         )

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,6 +14,7 @@ requires-python = ">=3.11"
 dependencies = [
   "pyyaml~=6.0",
   "aioconsole~=0.8",
+  "serialx>=1.4.0,<2",
 ]
 classifiers = [
   "Framework :: AsyncIO",

--- a/python_api.md
+++ b/python_api.md
@@ -3,9 +3,13 @@
 
 The library exposes a Python API through the **PioneerAVR** class. The class methods are listed below:
 
-`PioneerAVR.__init__(`_host_: **str**, _port_ = DEFAULT_PORT, _timeout_: **float** = DEFAULT_TIMEOUT, _scan_interval_: **float** = DEFAULT_SCAN_INTERVAL, _params_: **dict[str, str]** = **None** `)`
+`PioneerAVR.__init__(`url: **str**, _timeout_: **float** = DEFAULT_TIMEOUT, _scan_interval_: **float** = DEFAULT_SCAN_INTERVAL, _params_: **dict[str, str]** = **None** `)`
 
 Constructor for the **PioneerAVR** class. The connection parameters are used when `PioneerAVR.connect` is called. After connection is established, the AVR will be polled every _scan_interval_ seconds. If the `always_poll` parameter is set, the poll timer is reset when a response from the AVR is received. Optional user parameters are provided via _params_.
+
+This library uses SerialX for its connection handling. The `url` parameter must be formatted according to the protocols supported by SerialX; for more details, refer to the [SerialX Quickstart documentation](https://puddly.github.io/serialx/quickstart.html). 
+
+To access your AVR using a standard TCP socket (as in previous versions), use the `socket://<ip>:<port>` URL format, replacing `<ip>` and `<port>` with your AVR's IP address and port number (e.g., `socket://192.168.1.100:8102`).
 
 ## Connection methods (inherited by `PioneerAVR`)
 


### PR DESCRIPTION
Howdy! Its been a while ;)

This PR switches the library to use `serialx` for connection handling - the reason behind this is to support the new ESPHome serial proxies in Home Assistant, plus direct local USB based serial ports. It will also serve as a starting point for uplifting the existing legacy core pioneer integration.

A url could look like:

For local USB serial connections: `/dev/ttyUSB0`
For a remote TTY connection (such as the built in socket on the Pioneer): `socket://<ip>:<port>`
For esphome: https://puddly.github.io/serialx/how-to/esphome.html

- Added `serialx` as a dependency in `pyproject.toml`.
- Updated `AVRConnection` class to accept only a `url` parameter and refactored connection logic to utilize `serialx` for opening connections.
- Improved error handling by catching `serialx.SerialTimeoutException` for connection timeouts.